### PR TITLE
Suppot arbitrary stack size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,10 @@ travis-ci = { repository = "sval-rs/sval" }
 
 [features]
 # Support the standard library
-std = ["smallvec"]
+std = []
+
+# Support stacks with an arbitrary depth
+arbitrary-depth = ["std", "smallvec"]
 
 # Add a custom derive for `Value`
 derive = ["sval_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ travis-ci = { repository = "sval-rs/sval" }
 
 [features]
 # Support the standard library
-std = []
+std = ["smallvec"]
 
 # Add a custom derive for `Value`
 derive = ["sval_derive"]
@@ -43,6 +43,10 @@ test = ["std"]
 
 # Support integration with `serde`
 serde = ["std", "serde_lib/std"]
+
+[dependencies.smallvec]
+version = "0.6"
+optional = true
 
 [dependencies.serde_lib]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The `sval_json` crate can format any `sval::Value` as json:
 ```toml
 [dependencies.sval_json]
 version = "0.0.4"
+features = ["std"]
 ```
 
 ```rust

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -448,16 +448,20 @@ mod inner {
 
         #[inline]
         pub(super) fn pop_depth(&mut self) {
-            self.depth -= 1;
+            self.depth.saturating_sub(1);
         }
 
         #[inline]
         pub(super) fn current_mut(&mut self) -> &mut Slot {
+            // The depth is guaranteed to be in-bounds
+            // and pointing to initialized memory
             unsafe { self.slots.get_unchecked_mut(self.depth) }
         }
 
         #[inline]
         pub(super) fn current(&self) -> Slot {
+            // The depth is guaranteed to be in-bounds
+            // and pointing to initialized memory
             unsafe { *self.slots.get_unchecked(self.depth) }
         }
     }

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -470,11 +470,9 @@ mod inner {
     use super::{Slot, Error};
 
     #[derive(Clone)]
-    pub(super) struct Stack(SmallVec<[Slot; Self::SLOTS]>);
+    pub(super) struct Stack(SmallVec<[Slot; 16]>);
 
     impl Stack {
-        const SLOTS: usize = 16;
-
         #[inline]
         pub(super) fn new() -> Self {
             let mut slots = SmallVec::new();
@@ -514,25 +512,6 @@ mod inner {
         #[inline]
         pub(super) fn current(&self) -> Slot {
             *self.0.last().expect("missing stack slot")
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(feature = "std")]
-    mod std_support {
-        use crate::{
-            std::{
-                mem,
-                vec::Vec,
-            },
-            stream::stack::*,
-        };
-
-        #[test]
-        fn stack_is_not_bigger_than_vec() {
-            assert!(mem::size_of::<Stack>() <= mem::size_of::<Vec<Slot>>());
         }
     }
 }

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -465,19 +465,19 @@ mod inner {
 
 #[cfg(feature = "std")]
 mod inner {
-    use crate::std::vec::Vec;
+    use smallvec::SmallVec;
 
     use super::{Slot, Error};
 
     #[derive(Clone)]
-    pub(super) struct Stack(Vec<Slot>);
+    pub(super) struct Stack(SmallVec<[Slot; Self::SLOTS]>);
 
     impl Stack {
         const SLOTS: usize = 16;
 
         #[inline]
         pub(super) fn new() -> Self {
-            let mut slots = Vec::with_capacity(Self::SLOTS);
+            let mut slots = SmallVec::new();
             slots.push(Slot::root());
 
             Stack(slots)

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -412,7 +412,7 @@ mod inner {
 
     #[derive(Clone)]
     pub(super) struct Stack {
-        slots: [Slot; Self::SLOTS],
+        slots: [Slot; Stack::SLOTS],
         depth: usize,
     }
 

--- a/src/value/collect.rs
+++ b/src/value/collect.rs
@@ -15,6 +15,12 @@ use crate::{
     },
 };
 
+// FIXME: Moving the `*_collect` methods onto the base `Stream`
+// trait is a little more efficient (a few % improvement against `serde`)
+// in the general case because it can save a virtual call per key/value/elem.
+// The reason this hasn't been done already is just to reduce
+// the API surface area for now. It should be revisited sometime.
+
 /**
 An extension to `stream::Stream` for items that are known upfront.
 */


### PR DESCRIPTION
Closes #13 

Adds an alternative implementation of `Stack` that uses `smallvec::SmallVec` internally, instead of a fixed-size array. This requires the `std` feature so can't be used in `no_std` environments.

Dependents can opt in to bigger stacks using the `arbitrary-depth` Cargo feature. We'll probably make this default for `std` eventually.