### PR TITLE
Add support for derive_from = serde

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -3,16 +3,27 @@
 set -o errexit -o nounset
 
 # `sval` builds
+printf "\n\n---- sval ----\n\n"
 cargo test
+
+printf "\n\n---- sval with std ----\n\n"
 cargo test --features std
+
+printf "\n\n---- sval with serde ----\n\n"
 cargo test --features serde
+
+printf "\n\n---- sval with all features in release mode ----\n\n"
 cargo test --all-features --release
 
-# `sval_json` builds
+# sval_json builds
 pushd json
-cargo build
-cargo build --features std
+printf "\n\n---- sval_json ----\n\n"
+cargo test
+
+printf "\n\n---- sval_json with std ----\n\n"
+cargo test --features std
 popd
 
 # other builds
+printf "\n\n---- integration tests ----\n\n"
 cargo test --all --exclude sval_json_benches

--- a/derive/src/bound.rs
+++ b/derive/src/bound.rs
@@ -5,7 +5,7 @@ use syn::{
     WherePredicate,
 };
 
-pub fn where_clause_with_bound(generics: &Generics, bound: TokenStream) -> WhereClause {
+pub(crate) fn where_clause_with_bound(generics: &Generics, bound: TokenStream) -> WhereClause {
     let new_predicates = generics.type_params().map::<WherePredicate, _>(|param| {
         let param = &param.ident;
         parse_quote!(#param : #bound)

--- a/derive/src/value.rs
+++ b/derive/src/value.rs
@@ -12,7 +12,51 @@ use syn::{
     Ident,
 };
 
-pub fn derive(input: DeriveInput) -> TokenStream {
+pub(crate) fn derive(input: DeriveInput) -> TokenStream {
+    match attr::derive_provider(&input) {
+        attr::DeriveProvider::Sval => derive_from_sval(input),
+        attr::DeriveProvider::Serde => derive_from_serde(input),
+    }
+}
+
+/**
+Use an expected `serde::Serialize` implementation to derive `sval::Value`.
+*/
+pub(crate) fn derive_from_serde(input: DeriveInput) -> TokenStream {
+    let ident = input.ident;
+    let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
+    let dummy = Ident::new(
+        &format!("_IMPL_SVAL_VALUE_FOR_{}", ident),
+        Span::call_site(),
+    );
+
+    let bound = parse_quote!(sval::Value);
+    let bounded_where_clause = bound::where_clause_with_bound(&input.generics, bound);
+
+    TokenStream::from(quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy: () = {
+            extern crate sval;
+
+            impl #impl_generics sval::Value for #ident #ty_generics #bounded_where_clause {
+                fn stream(&self, stream: &mut sval::value::Stream) -> Result<(), sval::value::Error> {
+                    sval::derive_from_serde!(
+                        if #[cfg(feature = "serde")] {
+                            stream.any(sval::serde::to_value(self))
+                        }
+                        else {
+                            compile_error!("#[sval(derive_from = \"serde\")] requires the `serde` feature of `sval`")
+                        })
+                }
+            }
+        };
+    })
+}
+
+/**
+Construct an implementation of `sval::Value` based on the structure of the input.
+*/
+pub(crate) fn derive_from_sval(input: DeriveInput) -> TokenStream {
     let fields = match input.data {
         Data::Struct(DataStruct {
             fields: Fields::Named(fields),

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "serde")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! derive_from_serde {
+    (if #[cfg(feature = "serde")] { $($with:tt)* } else { $($without:tt)* } ) => {
+        $($with)*
+    };
+}
+
+#[cfg(not(feature = "serde"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! derive_from_serde {
+    (if #[cfg(feature = "serde")] { $($with:tt)* } else { $($without:tt)* } ) => {
+        $($without)*
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,9 +318,27 @@ Use the `serde` Cargo feature to enable integration with `serde`:
 [dependencies.sval]
 features = "serde"
 ```
+
+When `serde` is available, the `Value` trait can also be derived
+based on an existing `Serialize` implementation:
+
+```ignore
+use sval::Value;
+
+#[derive(Serialize, Value)]
+#[sval(derive_from = "serde")]
+pub enum Data {
+    Variant(i32, String),
+}
+# }
+```
 */
 
 #![no_std]
+
+#[doc(hidden)]
+#[cfg(feature = "derive")]
+pub mod derive;
 
 #[doc(inline)]
 #[cfg(feature = "derive")]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -19,7 +19,8 @@ use serde_test::{
     Token as SerdeToken,
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Value)]
+#[sval(derive_from = "serde")]
 enum Tagged {
     Unit,
     NewType(i32),
@@ -31,6 +32,7 @@ enum Tagged {
 struct Struct<'a> {
     a: i32,
     b: i32,
+    #[sval(rename = "renamed")]
     c: Nested<'a>,
 }
 
@@ -84,13 +86,31 @@ fn sval_derive() {
             Token::Signed(1),
             Token::Str(String::from("b")),
             Token::Signed(2),
-            Token::Str(String::from("c")),
+            Token::Str(String::from("renamed")),
             Token::MapBegin(Some(2)),
             Token::Str(String::from("a")),
             Token::Signed(3),
             Token::Str(String::from("b")),
             Token::Str(String::from("Hello!")),
             Token::MapEnd,
+            Token::MapEnd,
+        ],
+        v
+    );
+}
+
+#[test]
+fn sval_derive_from_serde() {
+    use self::SvalToken as Token;
+
+    let v = sval::test::tokens(Tagged::NewType(1));
+    assert_eq!(
+        vec![
+            Token::MapBegin(Some(1)),
+            Token::Str(String::from("NewType")),
+            Token::SeqBegin(Some(1)),
+            Token::Signed(1),
+            Token::SeqEnd,
             Token::MapEnd,
         ],
         v


### PR DESCRIPTION
Closes #7 

Allows you to write:

```rust
#[derive(Serialize, Value)]
#[sval(derive_from = "serde")]
enum MyData {
    ...
}
```

So that you can derive `sval::Value` using all of `serde`'s fancy features, and for types that `sval` itself doesn't directly support.

This requires the `serde` feature of `sval` to be enabled.