### PR TITLE
Clean up invalid example toml and add html_root_url attr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ keywords = ["serialization", "no_std"]
 categories = ["encoding", "no-std"]
 
 [package.metadata.docs.rs]
-features = ["derive", "serde"]
+features = ["derive", "serde", "test"]
 
 [badges]
 travis-ci = { repository = "sval-rs/sval" }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,6 +14,8 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
+#![doc(html_root_url = "https://docs.rs/sval_derive/0.1.0")]
+
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -5,6 +5,8 @@ This library is no-std, so it can be run in environments
 that don't have access to an allocator.
 */
 
+#![doc(html_root_url = "https://docs.rs/sval_json/0.1.0")]
+
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ Use the `serde` Cargo feature to enable integration with `serde`:
 
 ```toml,no_run
 [dependencies.sval]
-features = "serde"
+features = ["serde"]
 ```
 
 When `serde` is available, the `Value` trait can also be derived
@@ -333,6 +333,8 @@ pub enum Data {
 # }
 ```
 */
+
+#![doc(html_root_url = "https://docs.rs/sval/0.1.0")]
 
 #![no_std]
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,6 +1,13 @@
 /*!
 Integration between `sval` and `serde`.
 
+Add the `serde` feature to your `Cargo.toml` to enable this module:
+
+```toml,no_run
+[dependencies.sval]
+features = ["serde"]
+```
+
 # From `sval` to `serde`
 
 A type that implements [`sval::Value`](../value/trait.Value.html) can be converted into

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -82,6 +82,14 @@ looking at. The stack enforces:
 By default, stacks have a fixed depth (currently ~16, but this may change) so they can
 work in no-std environments. Each call to `map_begin` or `seq_begin` will increase the
 current depth. If this depth is exceeded then calls to `map_begin` or `seq_begin` will fail.
+
+The fixed-depth limit can be removed by adding the `arbitrary-depth` feature to your `Cargo.toml`
+(this also requires the standard library):
+
+```toml,no_run
+[dependencies.sval]
+features = ["arbitrary-depth"]
+```
 */
 #[derive(Clone)]
 pub struct Stack {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,13 @@
 /*!
 Helpers for testing value implementations.
 
+Add the `test` feature to your `Cargo.toml` to enable this module:
+
+```toml,no_run
+[dependencies.sval]
+features = ["test"]
+```
+
 > NOTE: The [`Token`](enum.Token.html) enum is expected to be non-exhaustively
 used in tests, so additional members aren't considered
 a breaking `semver` change.


### PR DESCRIPTION
There were a few issues with the example TOML in the docs. Also didn't have a `html_root_url` attribute, which prevents the docs for other libraries from linking back to `sval` types.