### PR TITLE
Avoid allocating for OwnedValues consisting of primitive values

### DIFF
--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "std")]
+#![feature(test)]
+
+extern crate sval;
+extern crate test;
+
+use sval::value;
+
+use test::{
+    black_box,
+    Bencher,
+};
+
+#[bench]
+fn collect_primitive(b: &mut Bencher) {
+    b.iter(|| {
+        let value = value::OwnedValue::from_value(1);
+
+        black_box(value);
+    })
+}
+
+#[bench]
+fn collect_primitive_string(b: &mut Bencher) {
+    b.iter(|| {
+        let value = value::OwnedValue::from_value("A string");
+
+        black_box(value);
+    })
+}
+
+#[bench]
+fn collect_complex(b: &mut Bencher) {
+    struct Map;
+
+    impl value::Value for Map {
+        fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+            stream.map_begin(None)?;
+
+            stream.map_key(1)?;
+
+            stream.map_value_begin()?.map_begin(None)?;
+
+            stream.map_key(2)?;
+
+            stream.map_value(42)?;
+
+            stream.map_end()?;
+
+            stream.map_end()
+        }
+    }
+
+    b.iter(|| {
+        let value = value::OwnedValue::from_value(Map);
+
+        black_box(value);
+    });
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -15,7 +15,6 @@ https://github.com/dtolnay/miniserde
 */
 
 #![doc(html_root_url = "https://docs.rs/sval_derive/0.1.1")]
-
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -6,7 +6,6 @@ that don't have access to an allocator.
 */
 
 #![doc(html_root_url = "https://docs.rs/sval_json/0.1.1")]
-
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,6 @@ pub enum Data {
 */
 
 #![doc(html_root_url = "https://docs.rs/sval/0.1.1")]
-
 #![no_std]
 
 #[doc(hidden)]

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -592,7 +592,7 @@ mod tests {
             Arbitrary,
             Gen,
         };
-        
+
         // FIXME: This test isn't very clever about how a
         // sequence of commands is generated. It's more likely
         // to come up with a set that fails early than one


### PR DESCRIPTION
Avoiding creating an `Arc<[Token]>` internally for `OwnedValue` if the given value is a simple primitive.