### PR TITLE
Deprecate OwnedValue::from_value in favour of OwnedValue::collect

### DIFF
--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -14,7 +14,7 @@ use test::{
 #[bench]
 fn collect_primitive(b: &mut Bencher) {
     b.iter(|| {
-        let value = value::OwnedValue::from_value(1);
+        let value = value::OwnedValue::collect(1);
 
         black_box(value);
     })
@@ -23,7 +23,7 @@ fn collect_primitive(b: &mut Bencher) {
 #[bench]
 fn collect_primitive_string(b: &mut Bencher) {
     b.iter(|| {
-        let value = value::OwnedValue::from_value("A string");
+        let value = value::OwnedValue::collect("A string");
 
         black_box(value);
     })
@@ -52,7 +52,7 @@ fn collect_complex(b: &mut Bencher) {
     }
 
     b.iter(|| {
-        let value = value::OwnedValue::from_value(Map);
+        let value = value::OwnedValue::collect(Map);
 
         black_box(value);
     });

--- a/src/test.rs
+++ b/src/test.rs
@@ -51,7 +51,7 @@ mod std_support {
     Collect a value into a sequence of tokens.
     */
     pub fn tokens(v: impl Value) -> Vec<Token> {
-        OwnedValue::from_value(v)
+        OwnedValue::collect(v)
             .tokens()
             .unwrap()
             .iter()

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -45,7 +45,7 @@ impl OwnedValue {
 
     [`Value`]: struct.Value.html
     */
-    pub fn from_value(v: impl Value) -> Self {
+    pub fn collect(v: impl Value) -> Self {
         // Try get a primitive first
         // If the value is a simple primitive that can
         // be represented in a single token then we can avoid
@@ -68,6 +68,11 @@ impl OwnedValue {
     */
     pub fn from_shared(v: impl Into<Arc<dyn Value + Send + Sync>>) -> Self {
         OwnedValue(ValueInner::Shared(v.into()))
+    }
+
+    #[deprecated(since = "0.1.2", note = "use `collect` instead")]
+    pub fn from_value(v: impl Value) -> Self {
+        Self::collect(v)
     }
 }
 


### PR DESCRIPTION
The `OwnedValue::from_value` function name didn't make it very obvious what's involved in converting some `impl Value` into an `OwnedValue`.

The new `OwnedValue::collect` name is similar to `Iterator::collect`, it suggests there's some work involved.