### PR TITLE
Prepare for 0.1.4 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "sval"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval"
@@ -62,7 +62,7 @@ default-features = false
 package = "serde"
 
 [dependencies.sval_derive]
-version = "0.1.3"
+version = "0.1.4"
 path = "./derive"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add `sval` to your crate dependencies:
 
 ```toml
 [dependencies.sval]
-version = "0.1.3"
+version = "0.1.4"
 ```
 
 ## To support my datastructures
@@ -81,7 +81,7 @@ The `sval_json` crate can format any `sval::Value` as json:
 
 ```toml
 [dependencies.sval_json]
-version = "0.1.3"
+version = "0.1.4"
 features = ["std"]
 ```
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_derive"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,7 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_derive/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/sval_derive/0.1.4")]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_json"
@@ -21,7 +21,7 @@ travis-ci = { repository = "KodrAus/sval" }
 std = ["sval/std"]
 
 [dependencies.sval]
-version = "0.1.3"
+version = "0.1.4"
 path = "../"
 
 [dependencies.ryu]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -5,7 +5,7 @@ This library is no-std, so it can be run in environments
 that don't have access to an allocator.
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_json/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/sval_json/0.1.4")]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/fmt/to_debug.rs
+++ b/src/fmt/to_debug.rs
@@ -77,7 +77,6 @@ impl<'a, 'b: 'a> Stream<'a, 'b> {
     }
 }
 
-// TODO: Support the indentation
 impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     #[inline]
     fn begin(&mut self) -> Result<(), stream::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval]
-version = "0.1.3"
+version = "0.1.4"
 ```
 
 # Streaming values
@@ -357,7 +357,7 @@ fn with_value(value: impl sval::Value) {
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/sval/0.1.4")]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
Includes:

- Support for treating a `sval::Value` like a `std::fmt::Debug` (#34)
- Fixes up building `sval_json` for no-std targets (#35)