### PR TITLE
Add some convenient Result types like fmt::Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ use sval::value::{self, Value};
 struct MyId(u64);
 
 impl Value for MyId {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.u64(self.0)
     }
 }

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -34,7 +34,7 @@ fn collect_complex(b: &mut Bencher) {
     struct Map;
 
     impl value::Value for Map {
-        fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             stream.map_begin(None)?;
 
             stream.map_key(1)?;

--- a/benches/stack.rs
+++ b/benches/stack.rs
@@ -19,57 +19,57 @@ struct EmptyStream;
 
 impl stream::Stream for EmptyStream {
     #[inline(never)]
-    fn fmt(&mut self, _: fmt::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, _: fmt::Arguments) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn u64(&mut self, _: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, _: u64) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn begin(&mut self) -> Result<(), stream::Error> {
+    fn begin(&mut self) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn end(&mut self) -> Result<(), stream::Error> {
+    fn end(&mut self) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn seq_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, _: Option<usize>) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn map_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, _: Option<usize>) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         Ok(())
     }
 
     #[inline(never)]
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         Ok(())
     }
 }
@@ -156,7 +156,7 @@ fn stream_map(b: &mut Bencher) {
     struct Map;
 
     impl value::Value for Map {
-        fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             stream.map_begin(None)?;
 
             stream.map_key(1)?;

--- a/json/src/fmt.rs
+++ b/json/src/fmt.rs
@@ -97,14 +97,14 @@ where
     W: Write,
 {
     #[inline]
-    fn begin(&mut self) -> Result<(), stream::Error> {
+    fn begin(&mut self) -> stream::Result {
         self.stack.begin()?;
 
         Ok(())
     }
 
     #[inline]
-    fn fmt(&mut self, v: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if let Some(delim) = mem::replace(&mut self.delim, Self::next_delim(pos)) {
@@ -119,7 +119,7 @@ where
     }
 
     #[inline]
-    fn i64(&mut self, v: i64) -> Result<(), stream::Error> {
+    fn i64(&mut self, v: i64) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {
@@ -138,7 +138,7 @@ where
     }
 
     #[inline]
-    fn u64(&mut self, v: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, v: u64) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {
@@ -157,7 +157,7 @@ where
     }
 
     #[inline]
-    fn f64(&mut self, v: f64) -> Result<(), stream::Error> {
+    fn f64(&mut self, v: f64) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {
@@ -176,7 +176,7 @@ where
     }
 
     #[inline]
-    fn bool(&mut self, v: bool) -> Result<(), stream::Error> {
+    fn bool(&mut self, v: bool) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {
@@ -195,7 +195,7 @@ where
     }
 
     #[inline]
-    fn char(&mut self, v: char) -> Result<(), stream::Error> {
+    fn char(&mut self, v: char) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {
@@ -214,7 +214,7 @@ where
     }
 
     #[inline]
-    fn str(&mut self, v: &str) -> Result<(), stream::Error> {
+    fn str(&mut self, v: &str) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if let Some(delim) = mem::replace(&mut self.delim, Self::next_delim(pos)) {
@@ -229,7 +229,7 @@ where
     }
 
     #[inline]
-    fn none(&mut self) -> Result<(), stream::Error> {
+    fn none(&mut self) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {
@@ -248,7 +248,7 @@ where
     }
 
     #[inline]
-    fn seq_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, _: Option<usize>) -> stream::Result {
         if self.stack.seq_begin()?.is_key() {
             return Err(stream::Error::msg(
                 "only strings are supported as json keys",
@@ -265,14 +265,14 @@ where
     }
 
     #[inline]
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         self.stack.seq_elem()?;
 
         Ok(())
     }
 
     #[inline]
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         let pos = self.stack.seq_end()?;
 
         self.delim = Self::next_delim(pos);
@@ -282,7 +282,7 @@ where
     }
 
     #[inline]
-    fn map_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, _: Option<usize>) -> stream::Result {
         if self.stack.map_begin()?.is_key() {
             return Err(stream::Error::msg(
                 "only strings are supported as json keys",
@@ -299,21 +299,21 @@ where
     }
 
     #[inline]
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         self.stack.map_key()?;
 
         Ok(())
     }
 
     #[inline]
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         self.stack.map_value()?;
 
         Ok(())
     }
 
     #[inline]
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         let pos = self.stack.map_end()?;
 
         self.delim = Self::next_delim(pos);
@@ -323,7 +323,7 @@ where
     }
 
     #[inline]
-    fn end(&mut self) -> Result<(), stream::Error> {
+    fn end(&mut self) -> stream::Result {
         self.stack.end()?;
 
         Ok(())

--- a/json/src/std_support.rs
+++ b/json/src/std_support.rs
@@ -95,87 +95,87 @@ where
     W: Write,
 {
     #[inline]
-    fn begin(&mut self) -> Result<(), stream::Error> {
+    fn begin(&mut self) -> stream::Result {
         self.0.begin()
     }
 
     #[inline]
-    fn fmt(&mut self, v: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
         self.0.fmt(v)
     }
 
     #[inline]
-    fn i64(&mut self, v: i64) -> Result<(), stream::Error> {
+    fn i64(&mut self, v: i64) -> stream::Result {
         self.0.i64(v)
     }
 
     #[inline]
-    fn u64(&mut self, v: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, v: u64) -> stream::Result {
         self.0.u64(v)
     }
 
     #[inline]
-    fn f64(&mut self, v: f64) -> Result<(), stream::Error> {
+    fn f64(&mut self, v: f64) -> stream::Result {
         self.0.f64(v)
     }
 
     #[inline]
-    fn bool(&mut self, v: bool) -> Result<(), stream::Error> {
+    fn bool(&mut self, v: bool) -> stream::Result {
         self.0.bool(v)
     }
 
     #[inline]
-    fn char(&mut self, v: char) -> Result<(), stream::Error> {
+    fn char(&mut self, v: char) -> stream::Result {
         self.0.char(v)
     }
 
     #[inline]
-    fn str(&mut self, v: &str) -> Result<(), stream::Error> {
+    fn str(&mut self, v: &str) -> stream::Result {
         self.0.str(v)
     }
 
     #[inline]
-    fn none(&mut self) -> Result<(), stream::Error> {
+    fn none(&mut self) -> stream::Result {
         self.0.none()
     }
 
     #[inline]
-    fn seq_begin(&mut self, len: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
         self.0.seq_begin(len)
     }
 
     #[inline]
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         self.0.seq_elem()
     }
 
     #[inline]
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         self.0.seq_end()
     }
 
     #[inline]
-    fn map_begin(&mut self, len: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
         self.0.map_begin(len)
     }
 
     #[inline]
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         self.0.map_key()
     }
 
     #[inline]
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         self.0.map_value()
     }
 
     #[inline]
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         self.0.map_end()
     }
 
     #[inline]
-    fn end(&mut self) -> Result<(), stream::Error> {
+    fn end(&mut self) -> stream::Result {
         self.0.end()
     }
 }

--- a/src/collect/mod.rs
+++ b/src/collect/mod.rs
@@ -34,11 +34,11 @@ pub(crate) use self::{
 An extension to `Stream` for items that are known upfront.
 */
 pub(crate) trait Collect: Stream {
-    fn map_key_collect(&mut self, k: Value) -> Result<(), Error>;
+    fn map_key_collect(&mut self, k: Value) -> Result;
 
-    fn map_value_collect(&mut self, v: Value) -> Result<(), Error>;
+    fn map_value_collect(&mut self, v: Value) -> Result;
 
-    fn seq_elem_collect(&mut self, v: Value) -> Result<(), Error>;
+    fn seq_elem_collect(&mut self, v: Value) -> Result;
 }
 
 impl<'a, S: ?Sized> Collect for &'a mut S
@@ -46,17 +46,17 @@ where
     S: Collect,
 {
     #[inline]
-    fn map_key_collect(&mut self, k: Value) -> Result<(), Error> {
+    fn map_key_collect(&mut self, k: Value) -> Result {
         (**self).map_key_collect(k)
     }
 
     #[inline]
-    fn map_value_collect(&mut self, v: Value) -> Result<(), Error> {
+    fn map_value_collect(&mut self, v: Value) -> Result {
         (**self).map_value_collect(v)
     }
 
     #[inline]
-    fn seq_elem_collect(&mut self, v: Value) -> Result<(), Error> {
+    fn seq_elem_collect(&mut self, v: Value) -> Result {
         (**self).seq_elem_collect(v)
     }
 }
@@ -71,7 +71,7 @@ where
     S: Stream,
 {
     #[inline]
-    fn map_key_collect(&mut self, k: Value) -> Result<(), Error> {
+    fn map_key_collect(&mut self, k: Value) -> Result {
         Stream::map_key(self)?;
         k.stream(self)?;
 
@@ -79,7 +79,7 @@ where
     }
 
     #[inline]
-    fn map_value_collect(&mut self, v: Value) -> Result<(), Error> {
+    fn map_value_collect(&mut self, v: Value) -> Result {
         Stream::map_value(self)?;
         v.stream(self)?;
 
@@ -87,7 +87,7 @@ where
     }
 
     #[inline]
-    fn seq_elem_collect(&mut self, v: Value) -> Result<(), Error> {
+    fn seq_elem_collect(&mut self, v: Value) -> Result {
         Stream::seq_elem(self)?;
         v.stream(self)?;
 
@@ -100,97 +100,99 @@ where
     S: Stream,
 {
     #[inline]
-    fn begin(&mut self) -> Result<(), Error> {
+    fn begin(&mut self) -> Result {
         self.0.begin()
     }
 
     #[inline]
-    fn fmt(&mut self, args: stream::Arguments) -> Result<(), Error> {
+    fn fmt(&mut self, args: stream::Arguments) -> Result {
         self.0.fmt(args)
     }
 
     #[inline]
-    fn i64(&mut self, v: i64) -> Result<(), Error> {
+    fn i64(&mut self, v: i64) -> Result {
         self.0.i64(v)
     }
 
     #[inline]
-    fn u64(&mut self, v: u64) -> Result<(), Error> {
+    fn u64(&mut self, v: u64) -> Result {
         self.0.u64(v)
     }
 
     #[inline]
-    fn i128(&mut self, v: i128) -> Result<(), Error> {
+    fn i128(&mut self, v: i128) -> Result {
         self.0.i128(v)
     }
 
     #[inline]
-    fn u128(&mut self, v: u128) -> Result<(), Error> {
+    fn u128(&mut self, v: u128) -> Result {
         self.0.u128(v)
     }
 
     #[inline]
-    fn f64(&mut self, v: f64) -> Result<(), Error> {
+    fn f64(&mut self, v: f64) -> Result {
         self.0.f64(v)
     }
 
     #[inline]
-    fn bool(&mut self, v: bool) -> Result<(), Error> {
+    fn bool(&mut self, v: bool) -> Result {
         self.0.bool(v)
     }
 
     #[inline]
-    fn char(&mut self, v: char) -> Result<(), Error> {
+    fn char(&mut self, v: char) -> Result {
         self.0.char(v)
     }
 
     #[inline]
-    fn str(&mut self, v: &str) -> Result<(), Error> {
+    fn str(&mut self, v: &str) -> Result {
         self.0.str(v)
     }
 
     #[inline]
-    fn none(&mut self) -> Result<(), Error> {
+    fn none(&mut self) -> Result {
         self.0.none()
     }
 
     #[inline]
-    fn map_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    fn map_begin(&mut self, len: Option<usize>) -> Result {
         self.0.map_begin(len)
     }
 
     #[inline]
-    fn map_key(&mut self) -> Result<(), Error> {
+    fn map_key(&mut self) -> Result {
         self.0.map_key()
     }
 
     #[inline]
-    fn map_value(&mut self) -> Result<(), Error> {
+    fn map_value(&mut self) -> Result {
         self.0.map_value()
     }
 
     #[inline]
-    fn map_end(&mut self) -> Result<(), Error> {
+    fn map_end(&mut self) -> Result {
         self.0.map_end()
     }
 
     #[inline]
-    fn seq_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    fn seq_begin(&mut self, len: Option<usize>) -> Result {
         self.0.seq_begin(len)
     }
 
     #[inline]
-    fn seq_elem(&mut self) -> Result<(), Error> {
+    fn seq_elem(&mut self) -> Result {
         self.0.seq_elem()
     }
 
     #[inline]
-    fn seq_end(&mut self) -> Result<(), Error> {
+    fn seq_end(&mut self) -> Result {
         self.0.seq_end()
     }
 
     #[inline]
-    fn end(&mut self) -> Result<(), Error> {
+    fn end(&mut self) -> Result {
         self.0.end()
     }
 }
+
+pub type Result = std::result::Result<(), Error>;

--- a/src/collect/owned.rs
+++ b/src/collect/owned.rs
@@ -1,5 +1,6 @@
 use crate::{
     collect::{
+        self,
         stack::{
             DebugBorrowMut,
             DebugStack,
@@ -28,14 +29,14 @@ where
     }
 
     #[inline]
-    pub fn any(&mut self, v: impl value::Value) -> Result<(), Error> {
+    pub fn any(&mut self, v: impl value::Value) -> collect::Result {
         let mut stream = value::Stream::new(&mut self.stream, self.stack.borrow_mut());
 
         stream.any(v)
     }
 
     #[inline]
-    pub fn fmt(&mut self, f: Arguments) -> Result<(), Error> {
+    pub fn fmt(&mut self, f: Arguments) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -46,7 +47,7 @@ where
     }
 
     #[inline]
-    pub fn i64(&mut self, v: i64) -> Result<(), Error> {
+    pub fn i64(&mut self, v: i64) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -55,7 +56,7 @@ where
     }
 
     #[inline]
-    pub fn u64(&mut self, v: u64) -> Result<(), Error> {
+    pub fn u64(&mut self, v: u64) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -66,7 +67,7 @@ where
     }
 
     #[inline]
-    pub fn i128(&mut self, v: i128) -> Result<(), Error> {
+    pub fn i128(&mut self, v: i128) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -75,7 +76,7 @@ where
     }
 
     #[inline]
-    pub fn u128(&mut self, v: u128) -> Result<(), Error> {
+    pub fn u128(&mut self, v: u128) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -84,7 +85,7 @@ where
     }
 
     #[inline]
-    pub fn f64(&mut self, v: f64) -> Result<(), Error> {
+    pub fn f64(&mut self, v: f64) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -93,7 +94,7 @@ where
     }
 
     #[inline]
-    pub fn bool(&mut self, v: bool) -> Result<(), Error> {
+    pub fn bool(&mut self, v: bool) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -102,7 +103,7 @@ where
     }
 
     #[inline]
-    pub fn char(&mut self, v: char) -> Result<(), Error> {
+    pub fn char(&mut self, v: char) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -111,7 +112,7 @@ where
     }
 
     #[inline]
-    pub fn str(&mut self, v: &str) -> Result<(), Error> {
+    pub fn str(&mut self, v: &str) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -120,7 +121,7 @@ where
     }
 
     #[inline]
-    pub fn none(&mut self) -> Result<(), Error> {
+    pub fn none(&mut self) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.primitive()?;
@@ -129,7 +130,7 @@ where
     }
 
     #[inline]
-    pub fn map_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    pub fn map_begin(&mut self, len: Option<usize>) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.map_begin()?;
@@ -138,7 +139,7 @@ where
     }
 
     #[inline]
-    pub fn map_key(&mut self, k: impl value::Value) -> Result<(), Error> {
+    pub fn map_key(&mut self, k: impl value::Value) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.map_key()?;
@@ -149,7 +150,7 @@ where
     }
 
     #[inline]
-    pub fn map_value(&mut self, v: impl value::Value) -> Result<(), Error> {
+    pub fn map_value(&mut self, v: impl value::Value) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.map_value()?;
@@ -160,7 +161,7 @@ where
     }
 
     #[inline]
-    pub fn map_end(&mut self) -> Result<(), Error> {
+    pub fn map_end(&mut self) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.map_end()?;
@@ -169,7 +170,7 @@ where
     }
 
     #[inline]
-    pub fn seq_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    pub fn seq_begin(&mut self, len: Option<usize>) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.seq_begin()?;
@@ -178,7 +179,7 @@ where
     }
 
     #[inline]
-    pub fn seq_elem(&mut self, v: impl value::Value) -> Result<(), Error> {
+    pub fn seq_elem(&mut self, v: impl value::Value) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.seq_elem()?;
@@ -189,7 +190,7 @@ where
     }
 
     #[inline]
-    pub fn seq_end(&mut self) -> Result<(), Error> {
+    pub fn seq_end(&mut self) -> collect::Result {
         let stream = &mut self.stream;
         self.stack.borrow_mut().and_then(|mut stack| {
             stack.seq_end()?;

--- a/src/collect/value.rs
+++ b/src/collect/value.rs
@@ -1,11 +1,11 @@
 use crate::{
     collect::{
+        self,
         stack::{
             DebugRefMut,
             DebugStack,
         },
         Collect,
-        Error,
     },
     value,
 };
@@ -28,7 +28,7 @@ impl<'a> Value<'a> {
     Stream this value.
     */
     #[inline]
-    pub(crate) fn stream(self, mut stream: impl Collect) -> Result<(), Error> {
+    pub(crate) fn stream(self, mut stream: impl Collect) -> collect::Result {
         let mut stream = value::Stream::new(&mut stream, self.stack);
 
         stream.any(self.value)?;

--- a/src/fmt/to_debug.rs
+++ b/src/fmt/to_debug.rs
@@ -78,14 +78,14 @@ impl<'a, 'b: 'a> Stream<'a, 'b> {
 
 impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     #[inline]
-    fn begin(&mut self) -> Result<(), stream::Error> {
+    fn begin(&mut self) -> stream::Result {
         self.stack.begin()?;
 
         Ok(())
     }
 
     #[inline]
-    fn fmt(&mut self, v: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         let next_delim = self.next_delim(pos);
@@ -99,42 +99,42 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
-    fn i64(&mut self, v: i64) -> Result<(), stream::Error> {
+    fn i64(&mut self, v: i64) -> stream::Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     #[inline]
-    fn u64(&mut self, v: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, v: u64) -> stream::Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     #[inline]
-    fn f64(&mut self, v: f64) -> Result<(), stream::Error> {
+    fn f64(&mut self, v: f64) -> stream::Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     #[inline]
-    fn bool(&mut self, v: bool) -> Result<(), stream::Error> {
+    fn bool(&mut self, v: bool) -> stream::Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     #[inline]
-    fn char(&mut self, v: char) -> Result<(), stream::Error> {
+    fn char(&mut self, v: char) -> stream::Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     #[inline]
-    fn str(&mut self, v: &str) -> Result<(), stream::Error> {
+    fn str(&mut self, v: &str) -> stream::Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     #[inline]
-    fn none(&mut self) -> Result<(), stream::Error> {
+    fn none(&mut self) -> stream::Result {
         self.fmt(format_args!("None"))
     }
 
     #[inline]
-    fn seq_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, _: Option<usize>) -> stream::Result {
         if self.is_pretty() {
             self.depth += 1;
         }
@@ -151,7 +151,7 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         if self.is_pretty() {
             if !self.stack.current().is_empty_seq() {
                 if let Some(delim) = self.delim.take() {
@@ -169,7 +169,7 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         if self.is_pretty() {
             self.depth -= 1;
 
@@ -193,7 +193,7 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
-    fn map_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, _: Option<usize>) -> stream::Result {
         if self.is_pretty() {
             self.depth += 1;
         }
@@ -210,7 +210,7 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         if self.is_pretty() {
             if !self.stack.current().is_empty_map() {
                 if let Some(delim) = self.delim.take() {
@@ -228,14 +228,14 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         self.stack.map_value()?;
 
         Ok(())
     }
 
     #[inline]
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         if self.is_pretty() {
             self.depth -= 1;
 
@@ -259,7 +259,7 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
-    fn end(&mut self) -> Result<(), stream::Error> {
+    fn end(&mut self) -> stream::Result {
         self.stack.end()?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ sval::stream(42, MyStream)?;
 # use sval::stream::{self, Stream};
 # struct MyStream;
 # impl Stream for MyStream {
-#     fn fmt(&mut self, _: stream::Arguments) -> Result<(), stream::Error> { unimplemented!() }
+#     fn fmt(&mut self, _: stream::Arguments) -> stream::Result { unimplemented!() }
 # }
 ```
 
@@ -67,7 +67,7 @@ use sval::value::{self, Value};
 pub struct Id(u64);
 
 impl Value for Id {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.u64(self.0)
     }
 }
@@ -83,7 +83,7 @@ use sval::value::{self, Value};
 pub struct Seq(Vec<u64>);
 
 impl Value for Seq {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(Some(self.0.len()))?;
 
         for v in &self.0 {
@@ -109,7 +109,7 @@ use sval::value::{self, Value};
 pub struct Map(BTreeMap<String, u64>);
 
 impl Value for Map {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(Some(self.0.len()))?;
 
         for (k, v) in &self.0 {
@@ -135,7 +135,7 @@ use sval::value::{self, Value};
 pub struct Map;
 
 impl Value for Map {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(Some(1))?;
 
         stream.map_key_begin()?.str("nested")?;
@@ -161,7 +161,7 @@ use sval::stream::{self, Stream};
 struct Fmt;
 
 impl Stream for Fmt {
-    fn fmt(&mut self, v: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
         println!("{}", v);
 
         Ok(())
@@ -191,13 +191,13 @@ pub fn is_u64(v: impl Value) -> bool {
 
 struct IsU64(Option<u64>);
 impl Stream for IsU64 {
-    fn u64(&mut self, v: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, v: u64) -> stream::Result {
         self.0 = Some(v);
 
         Ok(())
     }
 
-    fn fmt(&mut self, _: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, _: stream::Arguments) -> stream::Result {
         Err(stream::Error::msg("not a u64"))
     }
 }
@@ -234,7 +234,7 @@ impl Fmt {
 }
 
 impl Stream for Fmt {
-    fn fmt(&mut self, v: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         let delim = mem::replace(&mut self.delim, Self::next_delim(pos));
@@ -243,7 +243,7 @@ impl Stream for Fmt {
         Ok(())
     }
 
-    fn seq_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, _: Option<usize>) -> stream::Result {
         self.stack.seq_begin()?;
 
         let delim = mem::replace(&mut self.delim, "");
@@ -252,13 +252,13 @@ impl Stream for Fmt {
         Ok(())
     }
 
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         self.stack.seq_elem()?;
 
         Ok(())
     }
 
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         let pos = self.stack.seq_end()?;
 
         self.delim = Self::next_delim(pos);
@@ -267,7 +267,7 @@ impl Stream for Fmt {
         Ok(())
     }
 
-    fn map_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, _: Option<usize>) -> stream::Result {
         self.stack.map_begin()?;
 
         let delim = mem::replace(&mut self.delim, "");
@@ -276,19 +276,19 @@ impl Stream for Fmt {
         Ok(())
     }
 
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         self.stack.map_key()?;
 
         Ok(())
     }
 
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         self.stack.map_value()?;
 
         Ok(())
     }
 
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         let pos = self.stack.map_end()?;
 
         self.delim = Self::next_delim(pos);
@@ -297,7 +297,7 @@ impl Stream for Fmt {
         Ok(())
     }
 
-    fn end(&mut self) -> Result<(), stream::Error> {
+    fn end(&mut self) -> stream::Result {
         self.stack.end()?;
 
         println!();

--- a/src/serde/to_serialize.rs
+++ b/src/serde/to_serialize.rs
@@ -208,7 +208,7 @@ where
     End a buffer by serializing its contents.
     */
     #[inline]
-    fn buffer_end(&mut self) -> Result<(), stream::Error> {
+    fn buffer_end(&mut self) -> stream::Result {
         if let Some(mut buffered) = self.buffered.take() {
             let r = self.serialize_any(Tokens(buffered.tokens()));
 
@@ -247,7 +247,7 @@ where
     }
 
     #[inline]
-    fn serialize_any(&mut self, v: impl Serialize) -> Result<(), stream::Error> {
+    fn serialize_any(&mut self, v: impl Serialize) -> stream::Result {
         match self.pos.take() {
             Some(Pos::Key) => self.serialize_key(v),
             Some(Pos::Value) => self.serialize_value(v),
@@ -257,7 +257,7 @@ where
     }
 
     #[inline]
-    fn serialize_elem(&mut self, v: impl Serialize) -> Result<(), stream::Error> {
+    fn serialize_elem(&mut self, v: impl Serialize) -> stream::Result {
         self.expect()?
             .expect_serialize_seq()?
             .serialize_element(&v)
@@ -265,7 +265,7 @@ where
     }
 
     #[inline]
-    fn serialize_key(&mut self, k: impl Serialize) -> Result<(), stream::Error> {
+    fn serialize_key(&mut self, k: impl Serialize) -> stream::Result {
         self.expect()?
             .expect_serialize_map()?
             .serialize_key(&k)
@@ -273,7 +273,7 @@ where
     }
 
     #[inline]
-    fn serialize_value(&mut self, v: impl Serialize) -> Result<(), stream::Error> {
+    fn serialize_value(&mut self, v: impl Serialize) -> stream::Result {
         self.expect()?
             .expect_serialize_map()?
             .serialize_value(&v)
@@ -281,7 +281,7 @@ where
     }
 
     #[inline]
-    fn serialize_primitive(&mut self, v: impl Serialize) -> Result<(), stream::Error> {
+    fn serialize_primitive(&mut self, v: impl Serialize) -> stream::Result {
         let ser = self.take()?.take_serializer()?;
 
         self.ok = Some(
@@ -298,7 +298,7 @@ where
     S: Serializer,
 {
     #[inline]
-    fn map_key_collect(&mut self, k: collect::Value) -> Result<(), stream::Error> {
+    fn map_key_collect(&mut self, k: collect::Value) -> collect::Result {
         match self.buffer() {
             None => self.serialize_key(&ToSerialize(Value::new(k))),
             Some(buffered) => {
@@ -309,7 +309,7 @@ where
     }
 
     #[inline]
-    fn map_value_collect(&mut self, v: collect::Value) -> Result<(), stream::Error> {
+    fn map_value_collect(&mut self, v: collect::Value) -> collect::Result {
         match self.buffer() {
             None => self.serialize_value(&ToSerialize(Value::new(v))),
             Some(buffered) => {
@@ -320,7 +320,7 @@ where
     }
 
     #[inline]
-    fn seq_elem_collect(&mut self, v: collect::Value) -> Result<(), stream::Error> {
+    fn seq_elem_collect(&mut self, v: collect::Value) -> collect::Result {
         match self.buffer() {
             None => self.serialize_elem(&ToSerialize(Value::new(v))),
             Some(buffered) => {
@@ -336,7 +336,7 @@ where
     S: Serializer,
 {
     #[inline]
-    fn seq_begin(&mut self, len: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
         match self.buffer() {
             None => {
                 match self.take()? {
@@ -358,7 +358,7 @@ where
     }
 
     #[inline]
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         match self.buffer() {
             None => {
                 self.pos = Some(Pos::Elem);
@@ -370,7 +370,7 @@ where
     }
 
     #[inline]
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         match self.buffer() {
             None => {
                 let seq = self.take()?.take_serialize_seq()?;
@@ -391,7 +391,7 @@ where
     }
 
     #[inline]
-    fn map_begin(&mut self, len: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
         match self.buffer() {
             None => {
                 match self.take()? {
@@ -412,7 +412,7 @@ where
     }
 
     #[inline]
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         match self.buffer() {
             None => {
                 self.pos = Some(Pos::Key);
@@ -424,7 +424,7 @@ where
     }
 
     #[inline]
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         match self.buffer() {
             None => {
                 self.pos = Some(Pos::Value);
@@ -436,7 +436,7 @@ where
     }
 
     #[inline]
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         match self.buffer() {
             None => {
                 let map = self.take()?.take_serialize_map()?;
@@ -457,7 +457,7 @@ where
     }
 
     #[inline]
-    fn i64(&mut self, v: i64) -> Result<(), stream::Error> {
+    fn i64(&mut self, v: i64) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.i64(v),
@@ -465,7 +465,7 @@ where
     }
 
     #[inline]
-    fn u64(&mut self, v: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, v: u64) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.u64(v),
@@ -473,7 +473,7 @@ where
     }
 
     #[inline]
-    fn i128(&mut self, v: i128) -> Result<(), stream::Error> {
+    fn i128(&mut self, v: i128) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.i128(v),
@@ -481,7 +481,7 @@ where
     }
 
     #[inline]
-    fn u128(&mut self, v: u128) -> Result<(), stream::Error> {
+    fn u128(&mut self, v: u128) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.u128(v),
@@ -489,7 +489,7 @@ where
     }
 
     #[inline]
-    fn f64(&mut self, v: f64) -> Result<(), stream::Error> {
+    fn f64(&mut self, v: f64) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.f64(v),
@@ -497,7 +497,7 @@ where
     }
 
     #[inline]
-    fn bool(&mut self, v: bool) -> Result<(), stream::Error> {
+    fn bool(&mut self, v: bool) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.bool(v),
@@ -505,7 +505,7 @@ where
     }
 
     #[inline]
-    fn char(&mut self, v: char) -> Result<(), stream::Error> {
+    fn char(&mut self, v: char) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.char(v),
@@ -513,7 +513,7 @@ where
     }
 
     #[inline]
-    fn str(&mut self, v: &str) -> Result<(), stream::Error> {
+    fn str(&mut self, v: &str) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.str(v),
@@ -521,7 +521,7 @@ where
     }
 
     #[inline]
-    fn none(&mut self) -> Result<(), stream::Error> {
+    fn none(&mut self) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(Option::None::<()>),
             Some(buffered) => buffered.none(),
@@ -529,7 +529,7 @@ where
     }
 
     #[inline]
-    fn fmt(&mut self, v: fmt::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, v: fmt::Arguments) -> stream::Result {
         match self.buffer() {
             None => self.serialize_any(v),
             Some(buffered) => buffered.fmt(v),
@@ -579,7 +579,7 @@ impl<'a> TokensReader<'a> {
     }
 
     #[inline]
-    fn expect_empty(&self) -> Result<(), stream::Error> {
+    fn expect_empty(&self) -> stream::Result {
         if self.idx < self.tokens.len() {
             Err(stream::Error::msg("unexpected trailing tokens"))
         } else {

--- a/src/serde/to_value.rs
+++ b/src/serde/to_value.rs
@@ -26,7 +26,7 @@ impl<T> value::Value for ToValue<T>
 where
     T: Serialize,
 {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         self.0
             .serialize(Serializer(stream))
             .map_err(err("error streaming serde"))?;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -34,61 +34,61 @@ pub trait Stream {
     This method must be called before interacting with the stream
     in any other way.
     */
-    fn begin(&mut self) -> Result<(), Error> {
+    fn begin(&mut self) -> Result {
         Ok(())
     }
 
     /**
     Stream a format.
     */
-    fn fmt(&mut self, args: Arguments) -> Result<(), Error>;
+    fn fmt(&mut self, args: Arguments) -> Result;
 
     /**
     Stream a signed integer.
     */
-    fn i64(&mut self, v: i64) -> Result<(), Error> {
+    fn i64(&mut self, v: i64) -> Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     /**
     Stream an unsigned integer.
     */
-    fn u64(&mut self, v: u64) -> Result<(), Error> {
+    fn u64(&mut self, v: u64) -> Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     /**
     Stream a 128bit signed integer.
     */
-    fn i128(&mut self, v: i128) -> Result<(), Error> {
+    fn i128(&mut self, v: i128) -> Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     /**
     Stream a 128bit unsigned integer.
     */
-    fn u128(&mut self, v: u128) -> Result<(), Error> {
+    fn u128(&mut self, v: u128) -> Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     /**
     Stream a floating point value.
     */
-    fn f64(&mut self, v: f64) -> Result<(), Error> {
+    fn f64(&mut self, v: f64) -> Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     /**
     Stream a boolean.
     */
-    fn bool(&mut self, v: bool) -> Result<(), Error> {
+    fn bool(&mut self, v: bool) -> Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     /**
     Stream a unicode character.
     */
-    fn char(&mut self, v: char) -> Result<(), Error> {
+    fn char(&mut self, v: char) -> Result {
         let mut b = [0; 4];
         self.str(&*v.encode_utf8(&mut b))
     }
@@ -96,21 +96,21 @@ pub trait Stream {
     /**
     Stream a UTF-8 string slice.
     */
-    fn str(&mut self, v: &str) -> Result<(), Error> {
+    fn str(&mut self, v: &str) -> Result {
         self.fmt(format_args!("{:?}", v))
     }
 
     /**
     Stream an empty value.
     */
-    fn none(&mut self) -> Result<(), Error> {
+    fn none(&mut self) -> Result {
         self.fmt(format_args!("{:?}", ()))
     }
 
     /**
     Begin a map.
     */
-    fn map_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    fn map_begin(&mut self, len: Option<usize>) -> Result {
         let _ = len;
         Ok(())
     }
@@ -120,7 +120,7 @@ pub trait Stream {
 
     The key will be implicitly ended by the stream methods that follow it.
     */
-    fn map_key(&mut self) -> Result<(), Error> {
+    fn map_key(&mut self) -> Result {
         Ok(())
     }
 
@@ -129,21 +129,21 @@ pub trait Stream {
 
     The value will be implicitly ended by the stream methods that follow it.
     */
-    fn map_value(&mut self) -> Result<(), Error> {
+    fn map_value(&mut self) -> Result {
         Ok(())
     }
 
     /**
     End a map.
     */
-    fn map_end(&mut self) -> Result<(), Error> {
+    fn map_end(&mut self) -> Result {
         Ok(())
     }
 
     /**
     Begin a sequence.
     */
-    fn seq_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    fn seq_begin(&mut self, len: Option<usize>) -> Result {
         let _ = len;
         Ok(())
     }
@@ -153,21 +153,21 @@ pub trait Stream {
 
     The element will be implicitly ended by the stream methods that follow it.
     */
-    fn seq_elem(&mut self) -> Result<(), Error> {
+    fn seq_elem(&mut self) -> Result {
         Ok(())
     }
 
     /**
     End a sequence.
     */
-    fn seq_end(&mut self) -> Result<(), Error> {
+    fn seq_end(&mut self) -> Result {
         Ok(())
     }
 
     /**
     End the stream.
     */
-    fn end(&mut self) -> Result<(), Error> {
+    fn end(&mut self) -> Result {
         Ok(())
     }
 }
@@ -177,100 +177,105 @@ where
     T: Stream,
 {
     #[inline]
-    fn begin(&mut self) -> Result<(), Error> {
+    fn begin(&mut self) -> Result {
         (**self).begin()
     }
 
     #[inline]
-    fn fmt(&mut self, args: Arguments) -> Result<(), Error> {
+    fn fmt(&mut self, args: Arguments) -> Result {
         (**self).fmt(args)
     }
 
     #[inline]
-    fn i64(&mut self, v: i64) -> Result<(), Error> {
+    fn i64(&mut self, v: i64) -> Result {
         (**self).i64(v)
     }
 
     #[inline]
-    fn u64(&mut self, v: u64) -> Result<(), Error> {
+    fn u64(&mut self, v: u64) -> Result {
         (**self).u64(v)
     }
 
     #[inline]
-    fn i128(&mut self, v: i128) -> Result<(), Error> {
+    fn i128(&mut self, v: i128) -> Result {
         (**self).i128(v)
     }
 
     #[inline]
-    fn u128(&mut self, v: u128) -> Result<(), Error> {
+    fn u128(&mut self, v: u128) -> Result {
         (**self).u128(v)
     }
 
     #[inline]
-    fn f64(&mut self, v: f64) -> Result<(), Error> {
+    fn f64(&mut self, v: f64) -> Result {
         (**self).f64(v)
     }
 
     #[inline]
-    fn bool(&mut self, v: bool) -> Result<(), Error> {
+    fn bool(&mut self, v: bool) -> Result {
         (**self).bool(v)
     }
 
     #[inline]
-    fn char(&mut self, v: char) -> Result<(), Error> {
+    fn char(&mut self, v: char) -> Result {
         (**self).char(v)
     }
 
     #[inline]
-    fn str(&mut self, v: &str) -> Result<(), Error> {
+    fn str(&mut self, v: &str) -> Result {
         (**self).str(v)
     }
 
     #[inline]
-    fn none(&mut self) -> Result<(), Error> {
+    fn none(&mut self) -> Result {
         (**self).none()
     }
 
     #[inline]
-    fn map_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    fn map_begin(&mut self, len: Option<usize>) -> Result {
         (**self).map_begin(len)
     }
 
     #[inline]
-    fn map_key(&mut self) -> Result<(), Error> {
+    fn map_key(&mut self) -> Result {
         (**self).map_key()
     }
 
     #[inline]
-    fn map_value(&mut self) -> Result<(), Error> {
+    fn map_value(&mut self) -> Result {
         (**self).map_value()
     }
 
     #[inline]
-    fn map_end(&mut self) -> Result<(), Error> {
+    fn map_end(&mut self) -> Result {
         (**self).map_end()
     }
 
     #[inline]
-    fn seq_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    fn seq_begin(&mut self, len: Option<usize>) -> Result {
         (**self).seq_begin(len)
     }
 
     #[inline]
-    fn seq_elem(&mut self) -> Result<(), Error> {
+    fn seq_elem(&mut self) -> Result {
         (**self).seq_elem()
     }
 
     #[inline]
-    fn seq_end(&mut self) -> Result<(), Error> {
+    fn seq_end(&mut self) -> Result {
         (**self).seq_end()
     }
 
     #[inline]
-    fn end(&mut self) -> Result<(), Error> {
+    fn end(&mut self) -> Result {
         (**self).end()
     }
 }
+
+/**
+The type returned by streaming methods.
+*/
+pub type Result = std::result::Result<(), Error>;
 
 #[cfg(test)]
 mod tests {

--- a/src/stream/owned.rs
+++ b/src/stream/owned.rs
@@ -4,6 +4,7 @@ use crate::{
         OwnedCollect,
     },
     stream::{
+        self,
         Arguments,
         Error,
         Stream,
@@ -49,7 +50,7 @@ where
     Stream a value.
     */
     #[inline]
-    pub fn any(&mut self, v: impl Value) -> Result<(), Error> {
+    pub fn any(&mut self, v: impl Value) -> stream::Result {
         self.0.any(v)
     }
 
@@ -57,7 +58,7 @@ where
     Stream a format.
     */
     #[inline]
-    pub fn fmt(&mut self, f: Arguments) -> Result<(), Error> {
+    pub fn fmt(&mut self, f: Arguments) -> stream::Result {
         self.0.fmt(f)
     }
 
@@ -65,7 +66,7 @@ where
     Stream a signed integer.
     */
     #[inline]
-    pub fn i64(&mut self, v: i64) -> Result<(), Error> {
+    pub fn i64(&mut self, v: i64) -> stream::Result {
         self.0.i64(v)
     }
 
@@ -73,7 +74,7 @@ where
     Stream an unsigned integer.
     */
     #[inline]
-    pub fn u64(&mut self, v: u64) -> Result<(), Error> {
+    pub fn u64(&mut self, v: u64) -> stream::Result {
         self.0.u64(v)
     }
 
@@ -81,7 +82,7 @@ where
     Stream a 128-bit signed integer.
     */
     #[inline]
-    pub fn i128(&mut self, v: i128) -> Result<(), Error> {
+    pub fn i128(&mut self, v: i128) -> stream::Result {
         self.0.i128(v)
     }
 
@@ -89,7 +90,7 @@ where
     Stream a 128-bit unsigned integer.
     */
     #[inline]
-    pub fn u128(&mut self, v: u128) -> Result<(), Error> {
+    pub fn u128(&mut self, v: u128) -> stream::Result {
         self.0.u128(v)
     }
 
@@ -97,7 +98,7 @@ where
     Stream a floating point value.
     */
     #[inline]
-    pub fn f64(&mut self, v: f64) -> Result<(), Error> {
+    pub fn f64(&mut self, v: f64) -> stream::Result {
         self.0.f64(v)
     }
 
@@ -105,7 +106,7 @@ where
     Stream a boolean.
     */
     #[inline]
-    pub fn bool(&mut self, v: bool) -> Result<(), Error> {
+    pub fn bool(&mut self, v: bool) -> stream::Result {
         self.0.bool(v)
     }
 
@@ -113,7 +114,7 @@ where
     Stream a unicode character.
     */
     #[inline]
-    pub fn char(&mut self, v: char) -> Result<(), Error> {
+    pub fn char(&mut self, v: char) -> stream::Result {
         self.0.char(v)
     }
 
@@ -121,7 +122,7 @@ where
     Stream a UTF8 string.
     */
     #[inline]
-    pub fn str(&mut self, v: &str) -> Result<(), Error> {
+    pub fn str(&mut self, v: &str) -> stream::Result {
         self.0.str(v)
     }
 
@@ -129,7 +130,7 @@ where
     Stream an empty value.
     */
     #[inline]
-    pub fn none(&mut self) -> Result<(), Error> {
+    pub fn none(&mut self) -> stream::Result {
         self.0.none()
     }
 
@@ -137,7 +138,7 @@ where
     Begin a map.
     */
     #[inline]
-    pub fn map_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    pub fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
         self.0.map_begin(len)
     }
 
@@ -145,7 +146,7 @@ where
     Stream a map key.
     */
     #[inline]
-    pub fn map_key(&mut self, k: impl Value) -> Result<(), Error> {
+    pub fn map_key(&mut self, k: impl Value) -> stream::Result {
         self.0.map_key(k)
     }
 
@@ -153,7 +154,7 @@ where
     Stream a map value.
     */
     #[inline]
-    pub fn map_value(&mut self, v: impl Value) -> Result<(), Error> {
+    pub fn map_value(&mut self, v: impl Value) -> stream::Result {
         self.0.map_value(v)
     }
 
@@ -161,7 +162,7 @@ where
     End a map.
     */
     #[inline]
-    pub fn map_end(&mut self) -> Result<(), Error> {
+    pub fn map_end(&mut self) -> stream::Result {
         self.0.map_end()
     }
 
@@ -169,7 +170,7 @@ where
     Begin a sequence.
     */
     #[inline]
-    pub fn seq_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    pub fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
         self.0.seq_begin(len)
     }
 
@@ -177,7 +178,7 @@ where
     Stream a sequence element.
     */
     #[inline]
-    pub fn seq_elem(&mut self, v: impl Value) -> Result<(), Error> {
+    pub fn seq_elem(&mut self, v: impl Value) -> stream::Result {
         self.0.seq_elem(v)
     }
 
@@ -185,7 +186,7 @@ where
     End a sequence.
     */
     #[inline]
-    pub fn seq_end(&mut self) -> Result<(), Error> {
+    pub fn seq_end(&mut self) -> stream::Result {
         self.0.seq_end()
     }
 }

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -1,15 +1,14 @@
 use crate::{
     std::fmt,
     value::{
-        Error,
-        Stream,
+        self,
         Value,
     },
 };
 
 impl Value for () {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.none()
     }
 }
@@ -19,7 +18,7 @@ where
     T: Value,
 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         match self {
             Some(v) => v.stream(stream),
             None => stream.none(),
@@ -32,7 +31,7 @@ where
     T: Value,
 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(Some(self.len()))?;
 
         for v in self {
@@ -49,7 +48,7 @@ where
     U: Value,
 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(Some(2))?;
 
         stream.seq_elem(&self.0)?;
@@ -61,112 +60,112 @@ where
 
 impl Value for u8 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.u64(u64::from(*self))
     }
 }
 
 impl Value for u16 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.u64(u64::from(*self))
     }
 }
 
 impl Value for u32 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.u64(u64::from(*self))
     }
 }
 
 impl Value for u64 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.u64(*self)
     }
 }
 
 impl Value for i8 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.i64(i64::from(*self))
     }
 }
 
 impl Value for i16 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.i64(i64::from(*self))
     }
 }
 
 impl Value for i32 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.i64(i64::from(*self))
     }
 }
 
 impl Value for i64 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.i64(*self)
     }
 }
 
 impl Value for u128 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.u128(*self)
     }
 }
 
 impl Value for i128 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.i128(*self)
     }
 }
 
 impl Value for f32 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.f64(f64::from(*self))
     }
 }
 
 impl Value for f64 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.f64(*self)
     }
 }
 
 impl Value for bool {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.bool(*self)
     }
 }
 
 impl Value for char {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.char(*self)
     }
 }
 
 impl Value for str {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.str(self)
     }
 }
 
 impl<'a> Value for fmt::Arguments<'a> {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.fmt(*self)
     }
 }
@@ -196,7 +195,7 @@ mod std_support {
         T: Value,
     {
         #[inline]
-        fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             (**self).stream(stream)
         }
     }
@@ -207,7 +206,7 @@ mod std_support {
         T: Value,
     {
         #[inline]
-        fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             (**self).stream(stream)
         }
     }
@@ -217,14 +216,14 @@ mod std_support {
         T: Value,
     {
         #[inline]
-        fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             (**self).stream(stream)
         }
     }
 
     impl Value for String {
         #[inline]
-        fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             stream.str(&*self)
         }
     }
@@ -234,7 +233,7 @@ mod std_support {
         T: Value,
     {
         #[inline]
-        fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             self.as_slice().stream(stream)
         }
     }
@@ -245,7 +244,7 @@ mod std_support {
         V: Value,
     {
         #[inline]
-        fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             stream.map_begin(Some(self.len()))?;
 
             for (k, v) in self {
@@ -264,7 +263,7 @@ mod std_support {
         H: BuildHasher,
     {
         #[inline]
-        fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             stream.map_begin(Some(self.len()))?;
 
             for (k, v) in self {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -34,7 +34,7 @@ The following `Value` is valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         // VALID: The stream can take the primitive
         // value 42
         stream.any(42)
@@ -48,7 +48,7 @@ The following `Value` is not valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.any(42)?;
 
         // INVALID: The stream already received the
@@ -66,7 +66,7 @@ The following `Value` is valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
         stream.map_key("a")?;
         stream.map_value_begin()?.seq_begin(None)?;
@@ -84,7 +84,7 @@ The following `Value` is not valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
         stream.map_key("a")?;
         stream.map_value_begin()?.seq_begin(None)?;
@@ -103,7 +103,7 @@ The following `Value` is not valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         // INVALID: The map is never completed
@@ -120,7 +120,7 @@ The following `Value` is valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         // VALID: The `map_key` and `map_value` methods
@@ -144,7 +144,7 @@ The following `Value` is not valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         // INVALID: The underlying `map_key` and `map_value` methods
@@ -165,7 +165,7 @@ The following `Value` is valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         // VALID: The key is streamed before the value
@@ -183,7 +183,7 @@ The following `Value` is not valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         // INVALID: The value is streamed before the key
@@ -203,7 +203,7 @@ The following `Value` is valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(None)?;
 
         // VALID: The `seq_elem` method
@@ -225,7 +225,7 @@ The following `Value` is not valid:
 # use sval::value::{self, Value};
 # struct MyValue;
 impl Value for MyValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(None)?;
 
         // INVALID: The underlying `seq_elem` method
@@ -239,7 +239,7 @@ impl Value for MyValue {
 */
 pub trait Value {
     /** Stream this value. */
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error>;
+    fn stream(&self, stream: &mut Stream) -> Result;
 }
 
 impl<'a, T: ?Sized> Value for &'a T
@@ -247,10 +247,15 @@ where
     T: Value,
 {
     #[inline]
-    fn stream(&self, stream: &mut Stream) -> Result<(), Error> {
+    fn stream(&self, stream: &mut Stream) -> Result {
         (**self).stream(stream)
     }
 }
+
+/**
+The type returned by streaming methods.
+*/
+pub type Result = std::result::Result<(), Error>;
 
 #[cfg(test)]
 mod tests {

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -88,7 +88,7 @@ enum ValueInner {
 }
 
 impl Value for OwnedValue {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         match self.0 {
             ValueInner::Error(ref e) => Err(Error::custom(e)),
             ValueInner::Shared(ref v) => v.stream(stream),
@@ -151,7 +151,7 @@ pub(crate) struct Token {
 }
 
 impl Token {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         use self::Kind::*;
 
         match self.kind {
@@ -202,7 +202,7 @@ impl Buf {
 }
 
 impl Stream for Buf {
-    fn fmt(&mut self, f: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, f: stream::Arguments) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::Str(f.to_string()), depth);
@@ -210,7 +210,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn i64(&mut self, v: i64) -> Result<(), stream::Error> {
+    fn i64(&mut self, v: i64) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::Signed(v), depth);
@@ -218,7 +218,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn u64(&mut self, v: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, v: u64) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::Unsigned(v), depth);
@@ -226,7 +226,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn i128(&mut self, v: i128) -> Result<(), stream::Error> {
+    fn i128(&mut self, v: i128) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::BigSigned(v), depth);
@@ -234,7 +234,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn u128(&mut self, v: u128) -> Result<(), stream::Error> {
+    fn u128(&mut self, v: u128) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::BigUnsigned(v), depth);
@@ -242,7 +242,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn f64(&mut self, v: f64) -> Result<(), stream::Error> {
+    fn f64(&mut self, v: f64) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::Float(v), depth);
@@ -250,7 +250,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn bool(&mut self, v: bool) -> Result<(), stream::Error> {
+    fn bool(&mut self, v: bool) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::Bool(v), depth);
@@ -258,7 +258,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn char(&mut self, v: char) -> Result<(), stream::Error> {
+    fn char(&mut self, v: char) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::Char(v), depth);
@@ -266,7 +266,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn str(&mut self, v: &str) -> Result<(), stream::Error> {
+    fn str(&mut self, v: &str) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::Str(v.to_string()), depth);
@@ -274,7 +274,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn none(&mut self) -> Result<(), stream::Error> {
+    fn none(&mut self) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.push(Kind::None, depth);
@@ -282,7 +282,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn map_begin(&mut self, len: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
         let depth = self.stack.map_begin()?.depth();
 
         self.push(Kind::MapBegin(len), depth);
@@ -290,7 +290,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         let depth = self.stack.map_key()?.depth();
 
         self.push(Kind::MapKey, depth);
@@ -298,7 +298,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         let depth = self.stack.map_value()?.depth();
 
         self.push(Kind::MapValue, depth);
@@ -306,7 +306,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         let depth = self.stack.map_end()?.depth();
 
         self.push(Kind::MapEnd, depth);
@@ -314,7 +314,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn seq_begin(&mut self, len: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
         let depth = self.stack.seq_begin()?.depth();
 
         self.push(Kind::SeqBegin(len), depth);
@@ -322,7 +322,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         let depth = self.stack.seq_elem()?.depth();
 
         self.push(Kind::SeqElem, depth);
@@ -330,7 +330,7 @@ impl Stream for Buf {
         Ok(())
     }
 
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         let depth = self.stack.seq_end()?.depth();
 
         self.push(Kind::SeqEnd, depth);
@@ -364,7 +364,7 @@ impl Primitive {
 }
 
 impl Stream for Primitive {
-    fn fmt(&mut self, f: stream::Arguments) -> Result<(), stream::Error> {
+    fn fmt(&mut self, f: stream::Arguments) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::Str(f.to_string()), depth);
@@ -372,7 +372,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn i64(&mut self, v: i64) -> Result<(), stream::Error> {
+    fn i64(&mut self, v: i64) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::Signed(v), depth);
@@ -380,7 +380,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn u64(&mut self, v: u64) -> Result<(), stream::Error> {
+    fn u64(&mut self, v: u64) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::Unsigned(v), depth);
@@ -388,7 +388,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn i128(&mut self, v: i128) -> Result<(), stream::Error> {
+    fn i128(&mut self, v: i128) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::BigSigned(v), depth);
@@ -396,7 +396,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn u128(&mut self, v: u128) -> Result<(), stream::Error> {
+    fn u128(&mut self, v: u128) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::BigUnsigned(v), depth);
@@ -404,7 +404,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn f64(&mut self, v: f64) -> Result<(), stream::Error> {
+    fn f64(&mut self, v: f64) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::Float(v), depth);
@@ -412,7 +412,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn bool(&mut self, v: bool) -> Result<(), stream::Error> {
+    fn bool(&mut self, v: bool) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::Bool(v), depth);
@@ -420,7 +420,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn char(&mut self, v: char) -> Result<(), stream::Error> {
+    fn char(&mut self, v: char) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::Char(v), depth);
@@ -428,7 +428,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn str(&mut self, v: &str) -> Result<(), stream::Error> {
+    fn str(&mut self, v: &str) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::Str(v.to_string()), depth);
@@ -436,7 +436,7 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn none(&mut self) -> Result<(), stream::Error> {
+    fn none(&mut self) -> stream::Result {
         let depth = self.stack.primitive()?.depth();
 
         self.set(Kind::None, depth);
@@ -444,31 +444,31 @@ impl Stream for Primitive {
         Ok(())
     }
 
-    fn map_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn map_begin(&mut self, _: Option<usize>) -> stream::Result {
         Err(stream::Error::msg("unsupported primitive"))
     }
 
-    fn map_key(&mut self) -> Result<(), stream::Error> {
+    fn map_key(&mut self) -> stream::Result {
         Err(stream::Error::msg("unsupported primitive"))
     }
 
-    fn map_value(&mut self) -> Result<(), stream::Error> {
+    fn map_value(&mut self) -> stream::Result {
         Err(stream::Error::msg("unsupported primitive"))
     }
 
-    fn map_end(&mut self) -> Result<(), stream::Error> {
+    fn map_end(&mut self) -> stream::Result {
         Err(stream::Error::msg("unsupported primitive"))
     }
 
-    fn seq_begin(&mut self, _: Option<usize>) -> Result<(), stream::Error> {
+    fn seq_begin(&mut self, _: Option<usize>) -> stream::Result {
         Err(stream::Error::msg("unsupported primitive"))
     }
 
-    fn seq_elem(&mut self) -> Result<(), stream::Error> {
+    fn seq_elem(&mut self) -> stream::Result {
         Err(stream::Error::msg("unsupported primitive"))
     }
 
-    fn seq_end(&mut self) -> Result<(), stream::Error> {
+    fn seq_end(&mut self) -> stream::Result {
         Err(stream::Error::msg("unsupported primitive"))
     }
 }
@@ -513,7 +513,7 @@ mod tests {
     struct Map;
 
     impl Value for Map {
-        fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             stream.map_begin(Some(2))?;
 
             stream.map_key(1)?;
@@ -529,7 +529,7 @@ mod tests {
     struct Seq;
 
     impl Value for Seq {
-        fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
             stream.seq_begin(Some(2))?;
 
             stream.seq_elem(1)?;

--- a/src/value/stream.rs
+++ b/src/value/stream.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     stream::Arguments,
     value::{
+        self,
         Error,
         Value,
     },
@@ -36,7 +37,7 @@ impl<'a> Stream<'a> {
     Stream a value.
     */
     #[inline]
-    pub fn any(&mut self, v: impl Value) -> Result<(), Error> {
+    pub fn any(&mut self, v: impl Value) -> value::Result {
         v.stream(self)
     }
 
@@ -44,7 +45,7 @@ impl<'a> Stream<'a> {
     Stream a format.
     */
     #[inline]
-    pub fn fmt(&mut self, f: Arguments) -> Result<(), Error> {
+    pub fn fmt(&mut self, f: Arguments) -> value::Result {
         self.0.fmt(f)
     }
 
@@ -52,7 +53,7 @@ impl<'a> Stream<'a> {
     Stream a signed integer.
     */
     #[inline]
-    pub fn i64(&mut self, v: i64) -> Result<(), Error> {
+    pub fn i64(&mut self, v: i64) -> value::Result {
         self.0.i64(v)
     }
 
@@ -60,7 +61,7 @@ impl<'a> Stream<'a> {
     Stream an unsigned integer.
     */
     #[inline]
-    pub fn u64(&mut self, v: u64) -> Result<(), Error> {
+    pub fn u64(&mut self, v: u64) -> value::Result {
         self.0.u64(v)
     }
 
@@ -68,7 +69,7 @@ impl<'a> Stream<'a> {
     Stream a 128-bit signed integer.
     */
     #[inline]
-    pub fn i128(&mut self, v: i128) -> Result<(), Error> {
+    pub fn i128(&mut self, v: i128) -> value::Result {
         self.0.i128(v)
     }
 
@@ -76,7 +77,7 @@ impl<'a> Stream<'a> {
     Stream a 128-bit unsigned integer.
     */
     #[inline]
-    pub fn u128(&mut self, v: u128) -> Result<(), Error> {
+    pub fn u128(&mut self, v: u128) -> value::Result {
         self.0.u128(v)
     }
 
@@ -84,7 +85,7 @@ impl<'a> Stream<'a> {
     Stream a floating point value.
     */
     #[inline]
-    pub fn f64(&mut self, v: f64) -> Result<(), Error> {
+    pub fn f64(&mut self, v: f64) -> value::Result {
         self.0.f64(v)
     }
 
@@ -92,7 +93,7 @@ impl<'a> Stream<'a> {
     Stream a boolean.
     */
     #[inline]
-    pub fn bool(&mut self, v: bool) -> Result<(), Error> {
+    pub fn bool(&mut self, v: bool) -> value::Result {
         self.0.bool(v)
     }
 
@@ -100,7 +101,7 @@ impl<'a> Stream<'a> {
     Stream a unicode character.
     */
     #[inline]
-    pub fn char(&mut self, v: char) -> Result<(), Error> {
+    pub fn char(&mut self, v: char) -> value::Result {
         self.0.char(v)
     }
 
@@ -108,7 +109,7 @@ impl<'a> Stream<'a> {
     Stream a UTF8 string.
     */
     #[inline]
-    pub fn str(&mut self, v: &str) -> Result<(), Error> {
+    pub fn str(&mut self, v: &str) -> value::Result {
         self.0.str(v)
     }
 
@@ -116,7 +117,7 @@ impl<'a> Stream<'a> {
     Stream an empty value.
     */
     #[inline]
-    pub fn none(&mut self) -> Result<(), Error> {
+    pub fn none(&mut self) -> value::Result {
         self.0.none()
     }
 
@@ -124,7 +125,7 @@ impl<'a> Stream<'a> {
     Begin a map.
     */
     #[inline]
-    pub fn map_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    pub fn map_begin(&mut self, len: Option<usize>) -> value::Result {
         self.0.map_begin(len)
     }
 
@@ -132,7 +133,7 @@ impl<'a> Stream<'a> {
     Stream a map key.
     */
     #[inline]
-    pub fn map_key(&mut self, k: impl Value) -> Result<(), Error> {
+    pub fn map_key(&mut self, k: impl Value) -> value::Result {
         self.0.map_key(k)
     }
 
@@ -140,7 +141,7 @@ impl<'a> Stream<'a> {
     Stream a map value.
     */
     #[inline]
-    pub fn map_value(&mut self, v: impl Value) -> Result<(), Error> {
+    pub fn map_value(&mut self, v: impl Value) -> value::Result {
         self.0.map_value(v)
     }
 
@@ -148,7 +149,7 @@ impl<'a> Stream<'a> {
     End a map.
     */
     #[inline]
-    pub fn map_end(&mut self) -> Result<(), Error> {
+    pub fn map_end(&mut self) -> value::Result {
         self.0.map_end()
     }
 
@@ -156,7 +157,7 @@ impl<'a> Stream<'a> {
     Begin a sequence.
     */
     #[inline]
-    pub fn seq_begin(&mut self, len: Option<usize>) -> Result<(), Error> {
+    pub fn seq_begin(&mut self, len: Option<usize>) -> value::Result {
         self.0.seq_begin(len)
     }
 
@@ -164,7 +165,7 @@ impl<'a> Stream<'a> {
     Stream a sequence element.
     */
     #[inline]
-    pub fn seq_elem(&mut self, v: impl Value) -> Result<(), Error> {
+    pub fn seq_elem(&mut self, v: impl Value) -> value::Result {
         self.0.seq_elem(v)
     }
 
@@ -172,7 +173,7 @@ impl<'a> Stream<'a> {
     End a sequence.
     */
     #[inline]
-    pub fn seq_end(&mut self) -> Result<(), Error> {
+    pub fn seq_end(&mut self) -> value::Result {
         self.0.seq_end()
     }
 }

--- a/tests/fmt/lib.rs
+++ b/tests/fmt/lib.rs
@@ -29,7 +29,7 @@ impl Debug for OuterMap {
 }
 
 impl Value for OuterMap {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         stream.map_key(1)?;
@@ -67,7 +67,7 @@ impl Debug for InnerMap {
 }
 
 impl Value for InnerMap {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         stream.map_key(1)?;
@@ -89,7 +89,7 @@ impl Debug for EmptyMap {
 }
 
 impl Value for EmptyMap {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
         stream.map_end()
     }
@@ -112,7 +112,7 @@ impl Debug for OuterSeq {
 }
 
 impl Value for OuterSeq {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(None)?;
 
         stream.seq_elem(1)?;
@@ -139,7 +139,7 @@ impl Debug for InnerSeq {
 }
 
 impl Value for InnerSeq {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(None)?;
 
         stream.seq_elem(1)?;
@@ -158,7 +158,7 @@ impl Debug for EmptySeq {
 }
 
 impl Value for EmptySeq {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.seq_begin(None)?;
         stream.seq_end()
     }
@@ -177,7 +177,7 @@ impl Debug for WeirdMapKeys {
 }
 
 impl Value for WeirdMapKeys {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         stream.map_key(InnerMap)?;

--- a/tests/serde/lib.rs
+++ b/tests/serde/lib.rs
@@ -45,7 +45,7 @@ struct Nested<'a> {
 struct Anonymous;
 
 impl Value for Anonymous {
-    fn stream(&self, stream: &mut value::Stream) -> Result<(), value::Error> {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
         stream.map_begin(None)?;
 
         stream.map_key_begin()?.i64(1)?;


### PR DESCRIPTION
Introduces a few convenient `Result` type aliases like `fmt::Result` for implementing streams and values:

- `value::Result = Result<(), value::Error>`
- `stream::Result = Result<(), stream::Error>`