### PR TITLE
Reverse order of args so they're always stream first like serde

### DIFF
--- a/benches/stack.rs
+++ b/benches/stack.rs
@@ -179,5 +179,5 @@ fn stream_map(b: &mut Bencher) {
         }
     }
 
-    b.iter(|| sval::stream(Map, EmptyStream))
+    b.iter(|| sval::stream(EmptyStream, Map))
 }

--- a/json/src/fmt.rs
+++ b/json/src/fmt.rs
@@ -19,7 +19,7 @@ Write a [`sval::Value`] to a formatter.
 pub fn to_fmt(fmt: impl Write, v: impl sval::Value) -> Result<(), sval::Error> {
     let fmt = Formatter::new(fmt);
 
-    sval::stream(v, fmt)
+    sval::stream(fmt, v)
 }
 
 /**

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -3,6 +3,73 @@ JSON support for `sval`.
 
 This library is no-std, so it can be run in environments
 that don't have access to an allocator.
+
+# Getting started
+
+Add `sval_json` to your `Cargo.toml`:
+
+```toml,ignore
+[dependencies.sval_json]
+version = "0.1.5"
+```
+
+# Writing JSON to `fmt::Write`
+
+```no_run
+# #[cfg(not(feature = "std"))]
+# fn main() {}
+# #[cfg(feature = "std")]
+# fn main() -> Result<(), Box<std::error::Error>> {
+let json = sval_json::to_fmt(MyWrite, 42)?;
+# Ok(())
+# }
+# use std::fmt::{self, Write};
+# struct MyWrite;
+# impl Write for MyWrite {
+#     fn write_str(&mut self, _: &str) -> fmt::Result {
+#         Ok(())
+#     }
+# }
+```
+
+# Writing JSON to a `String`
+
+Add the `std` feature to your `Cargo.toml` to enable this module:
+
+```toml,no_run
+[dependencies.sval_json]
+features = ["std"]
+```
+
+```no_run
+# #[cfg(not(feature = "std"))]
+# fn main() {}
+# #[cfg(feature = "std")]
+# fn main() -> Result<(), Box<std::error::Error>> {
+let json = sval_json::to_string(42)?;
+# Ok(())
+# }
+```
+
+# Writing JSON to a `io::Write`
+
+```no_run
+# #[cfg(not(feature = "std"))]
+# fn main() {}
+# #[cfg(feature = "std")]
+# fn main() -> Result<(), Box<std::error::Error>> {
+# use std::io::{self, Write};
+# struct MyWrite;
+# impl Write for MyWrite {
+#     fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+#         Ok(0)
+#     }
+#     fn flush(&mut self) -> io::Result<()> { Ok(()) }
+# }
+let json = sval_json::to_writer(MyWrite, 42)?;
+# Ok(())
+# }
+```
 */
 
 #![doc(html_root_url = "https://docs.rs/sval_json/0.1.5")]

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -51,6 +51,6 @@ pub fn to_debug(value: impl Value) -> impl Debug {
 /**
 Format a [`Value`] using the given [`Formatter`].
 */
-pub fn debug(value: impl Value, f: &mut Formatter) -> fmt::Result {
+pub fn debug(f: &mut Formatter, value: impl Value) -> fmt::Result {
     to_debug(value).fmt(f)
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -71,7 +71,7 @@ pub fn to_serialize(value: impl Value) -> impl Serialize {
 /**
 Serialize a [`Value`] using the given [`Serializer`].
 */
-pub fn serialize<S>(value: impl Value, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize<S>(serializer: S, value: impl Value) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -88,6 +88,6 @@ pub fn to_value(value: impl Serialize) -> impl Value {
 /**
 Stream a [`Serialize`] using the given [`Stream`].
 */
-pub fn stream(value: impl Serialize, stream: impl Stream) -> Result<(), Error> {
+pub fn stream(stream: impl Stream, value: impl Serialize) -> Result<(), Error> {
     crate::stream(to_value(value), stream)
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -89,5 +89,5 @@ pub fn to_value(value: impl Serialize) -> impl Value {
 Stream a [`Serialize`] using the given [`Stream`].
 */
 pub fn stream(stream: impl Stream, value: impl Serialize) -> Result<(), Error> {
-    crate::stream(to_value(value), stream)
+    crate::stream(stream, to_value(value))
 }

--- a/src/stream/owned.rs
+++ b/src/stream/owned.rs
@@ -30,7 +30,7 @@ where
     Stream a value.
     */
     #[inline]
-    pub fn stream(value: impl Value, stream: S) -> Result<S, Error> {
+    pub fn stream(stream: S, value: impl Value) -> Result<S, Error> {
         let mut stream = Self::begin(stream)?;
         stream.any(value)?;
         stream.end()

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -112,7 +112,7 @@ impl Debug for OwnedValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(feature = "fmt")]
         {
-            crate::fmt::debug(self, f)
+            crate::fmt::debug(f, self)
         }
 
         #[cfg(not(feature = "fmt"))]

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -197,7 +197,7 @@ impl Buf {
 
     fn collect(v: impl Value) -> Result<Vec<Token>, stream::Error> {
         let mut buf = Buf::new();
-        crate::stream(v, &mut buf).map(|_| buf.tokens)
+        crate::stream(&mut buf, v).map(|_| buf.tokens)
     }
 
     fn push(&mut self, kind: Kind, depth: stack::Depth) {
@@ -359,7 +359,7 @@ impl Primitive {
     fn collect(v: impl Value) -> Option<Token> {
         let mut buf = Primitive::new();
 
-        crate::stream(v, &mut buf).ok().and_then(|_| buf.token)
+        crate::stream(&mut buf, v).ok().and_then(|_| buf.token)
     }
 
     fn set(&mut self, kind: Kind, depth: stack::Depth) {


### PR DESCRIPTION
This is a breaking change.

Always pass the stream argument before the value argument as in `serde_json`.