### PR TITLE
prepare for 0.3.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "sval"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval"
@@ -62,7 +62,7 @@ default-features = false
 package = "serde"
 
 [dependencies.sval_derive]
-version = "0.3.0"
+version = "0.3.1"
 path = "./derive"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This library is designed to plug a no-std-object-safe sized hole in Rust's curre
 
 **`sval_json` and `sval_derive` are mostly pilfered from dtolnay's [excellent `miniserde` project](https://github.com/dtolnay/miniserde).**
 
+# Supported formats
+
+- [JSON](https://crates.io/crates/sval_json)
+
 # Minimum `rustc`
 
 This library requires Rust `1.31.0`.
@@ -39,7 +43,7 @@ Add `sval` to your crate dependencies:
 
 ```toml
 [dependencies.sval]
-version = "0.3.0"
+version = "0.3.1"
 ```
 
 ## To support my datastructures
@@ -82,7 +86,7 @@ The `sval_json` crate can format any `sval::Value` as json:
 
 ```toml
 [dependencies.sval_json]
-version = "0.3.0"
+version = "0.3.1"
 features = ["std"]
 ```
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_derive"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,7 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_derive/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/sval_derive/0.3.1")]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_json"
@@ -9,7 +9,7 @@ repository = "https://github.com/sval-rs/sval"
 license = "Apache-2.0 OR MIT"
 keywords = ["serialization", "json", "no_std"]
 categories = ["encoding", "no-std"]
-readme = "../README.md"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 features = ["std"]
@@ -21,7 +21,7 @@ travis-ci = { repository = "KodrAus/sval" }
 std = ["sval/std"]
 
 [dependencies.sval]
-version = "0.3.0"
+version = "0.3.1"
 path = "../"
 
 [dependencies.ryu]

--- a/json/README.md
+++ b/json/README.md
@@ -1,0 +1,61 @@
+# `sval_json`
+
+[![Build Status](https://travis-ci.com/sval-rs/sval.svg?branch=master)](https://travis-ci.com/sval-rs/sval)
+[![Latest version](https://img.shields.io/crates/v/sval_json.svg)](https://crates.io/crates/sval_json)
+[![Documentation Latest](https://docs.rs/sval_json/badge.svg)](https://docs.rs/sval_json)
+[![Documentation Master](https://img.shields.io/badge/docs-master-lightgrey.svg)](https://sval-rs.github.io/sval/sval_json/index.html)
+
+A no-std JSON implementation for the [`sval`](crates.io/crates/sval) serialization framework.
+
+**`sval_json` is mostly pilfered from dtolnay's [excellent `miniserde` project](https://github.com/dtolnay/miniserde).**
+
+# Minimum `rustc`
+
+This library requires Rust `1.31.0`.
+
+# Cargo features
+
+`sval_json` has the following optional features that can be enabled in your `Cargo.toml`:
+
+- `std`: assume `std` is available and add support for `std` types.
+
+# How to use it
+
+Add `sval_json` to your crate dependencies:
+
+```toml
+[dependencies.sval_json]
+version = "0.3.1"
+```
+
+## To write JSON to a `fmt::Write`
+
+```rust
+let json = sval_json::to_fmt(MyWrite, 42)?;
+```
+
+## To write JSON to a `String`
+
+Add the `std` feature to your `Cargo.toml` to enable writing to a `String`:
+
+```toml
+[dependencies.sval_json]
+features = ["std"]
+```
+
+```rust
+let json = sval_json::to_string(42)?;
+```
+
+## To write JSON to a `io::Write`
+
+Add the `std` feature to your `Cargo.toml` to enable writing to an `io::Write`:
+
+```toml
+[dependencies.sval_json]
+features = ["std"]
+```
+
+```rust
+let json = sval_json::to_writer(MyWrite, 42)?;
+```

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -10,7 +10,7 @@ Add `sval_json` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval_json]
-version = "0.3.0"
+version = "0.3.1"
 ```
 
 # Writing JSON to `fmt::Write`
@@ -34,7 +34,7 @@ let json = sval_json::to_fmt(MyWrite, 42)?;
 
 # Writing JSON to a `String`
 
-Add the `std` feature to your `Cargo.toml` to enable this module:
+Add the `std` feature to your `Cargo.toml` to enable writing to a `String`:
 
 ```toml,no_run
 [dependencies.sval_json]
@@ -52,6 +52,13 @@ let json = sval_json::to_string(42)?;
 ```
 
 # Writing JSON to a `io::Write`
+
+Add the `std` feature to your `Cargo.toml` to enable writing to an `io::Write`:
+
+```toml,no_run
+[dependencies.sval_json]
+features = ["std"]
+```
 
 ```no_run
 # #[cfg(not(feature = "std"))]
@@ -72,7 +79,7 @@ let json = sval_json::to_writer(MyWrite, 42)?;
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_json/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/sval_json/0.3.1")]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,12 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval]
-version = "0.3.0"
+version = "0.3.1"
 ```
+
+# Supported formats
+
+- [JSON](https://crates.io/crates/sval_json)
 
 # Streaming values
 
@@ -419,7 +423,7 @@ fn with_value(value: impl sval::Value) {
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/sval/0.3.1")]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
Tidies up some docs so users who find their way to `sval_json` via crates.io don't see the `sval` readme.