### PR TITLE
prepare for 0.4.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "sval"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval"
@@ -62,7 +62,7 @@ default-features = false
 package = "serde"
 
 [dependencies.sval_derive]
-version = "0.3.1"
+version = "0.4.0"
 path = "./derive"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 [![Documentation Latest](https://docs.rs/sval/badge.svg)](https://docs.rs/sval)
 [![Documentation Master](https://img.shields.io/badge/docs-master-lightgrey.svg)](https://sval-rs.github.io/sval/sval/index.html)
 
-A lightweight, no-std, object-safe, serialization-only API for structured values with `serde` support.
+A lightweight, no-std, object-safe, serialization-only API for structured values with `serde` and `std::fmt` support.
 
-Producers of structured values use the `value` module. Consumers of structured values use the `stream` module. `sval` offers a json-like data model, which is more limiting than `serde`'s, but capable enough to represent Rust datastructures in one form or another.
+Producers of structured values use the `value` module. Consumers of structured values use the `stream` module.
+
+`sval` offers a JSON-like data model, which is more limiting than `serde`'s, but capable enough to represent Rust data-structures in one form or another.
 
 This library is designed to plug a no-std-object-safe sized hole in Rust's current serialization ecosystem. The driving use-case is structured logging, where individual events are typically small, and there's no complete schema that can tie values in any one event to values in another.
 
@@ -15,7 +17,7 @@ This library is designed to plug a no-std-object-safe sized hole in Rust's curre
 
 # Supported formats
 
-- [JSON](https://crates.io/crates/sval_json)
+- [JSON](https://crates.io/crates/sval_json), the ubiquitous JavaScript Object Notation used by many HTTP APIs.
 
 # Minimum `rustc`
 
@@ -43,12 +45,12 @@ Add `sval` to your crate dependencies:
 
 ```toml
 [dependencies.sval]
-version = "0.3.1"
+version = "0.4.0"
 ```
 
-## To support my datastructures
+## To support my data-structures
 
-Simple struct-like datastructures can derive `sval::Value`:
+Simple struct-like data-structures can derive `sval::Value`:
 
 ```toml
 [dependencies.sval]
@@ -86,7 +88,7 @@ The `sval_json` crate can format any `sval::Value` as json:
 
 ```toml
 [dependencies.sval_json]
-version = "0.3.1"
+version = "0.4.0"
 features = ["std"]
 ```
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_derive"
@@ -11,7 +11,11 @@ license = "Apache-2.0 OR MIT"
 [lib]
 proc-macro = true
 
-[dependencies]
-syn = "0.15"
-quote = "0.6"
-proc-macro2 = "0.4"
+[dependencies.syn]
+version = "0.15"
+
+[dependencies.quote]
+version = "0.6"
+
+[dependencies.proc-macro2]
+version = "0.4"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,7 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_derive/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/sval_derive/0.4.0")]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sval_json"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_json"
-description = "Json support for the sval serialization framework"
+description = "JSON support for the sval serialization framework"
 repository = "https://github.com/sval-rs/sval"
 license = "Apache-2.0 OR MIT"
 keywords = ["serialization", "json", "no_std"]
@@ -18,10 +18,11 @@ features = ["std"]
 travis-ci = { repository = "KodrAus/sval" }
 
 [features]
+# Support the standard library
 std = ["sval/std"]
 
 [dependencies.sval]
-version = "0.3.1"
+version = "0.4.0"
 path = "../"
 
 [dependencies.ryu]

--- a/json/README.md
+++ b/json/README.md
@@ -5,7 +5,7 @@
 [![Documentation Latest](https://docs.rs/sval_json/badge.svg)](https://docs.rs/sval_json)
 [![Documentation Master](https://img.shields.io/badge/docs-master-lightgrey.svg)](https://sval-rs.github.io/sval/sval_json/index.html)
 
-A no-std JSON implementation for the [`sval`](crates.io/crates/sval) serialization framework.
+A no-std JSON implementation for the [`sval`](https://crates.io/crates/sval) serialization framework.
 
 **`sval_json` is mostly pilfered from dtolnay's [excellent `miniserde` project](https://github.com/dtolnay/miniserde).**
 
@@ -25,7 +25,7 @@ Add `sval_json` to your crate dependencies:
 
 ```toml
 [dependencies.sval_json]
-version = "0.3.1"
+version = "0.4.0"
 ```
 
 ## To write JSON to a `fmt::Write`

--- a/json/src/fmt.rs
+++ b/json/src/fmt.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         mem,
     },
-    IntoInner,
+    End,
 };
 
 /**
@@ -85,10 +85,10 @@ where
     If the writer contains incomplete json then this method will fail.
     The returned error can be used to pull the original stream back out.
     */
-    pub fn end(mut self) -> Result<W, IntoInner<Self>> {
+    pub fn end(mut self) -> Result<W, End<Self>> {
         match self.stack.end() {
             Ok(()) => Ok(self.out),
-            Err(e) => Err(IntoInner::new(e, self)),
+            Err(e) => Err(End::new(e, self)),
         }
     }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -10,7 +10,7 @@ Add `sval_json` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval_json]
-version = "0.3.1"
+version = "0.4.0"
 ```
 
 # Writing JSON to `fmt::Write`
@@ -79,7 +79,7 @@ let json = sval_json::to_writer(MyWrite, 42)?;
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_json/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/sval_json/0.4.0")]
 #![no_std]
 
 #[cfg(feature = "std")]
@@ -105,36 +105,38 @@ pub use self::std_support::{
 };
 
 /**
-An error attempting to get an inner writer containing json.
+An error attempting to end a JSON stream.
+
+The original stream can be pulled out, or this type can be treated as a standard error.
 */
-pub struct IntoInner<T> {
-    /** The original value. */
-    pub value: T,
+pub struct End<T> {
+    /** The original stream. */
+    pub stream: T,
     err: sval::Error,
     _private: (),
 }
 
-impl<T> IntoInner<T> {
-    fn new(err: sval::Error, value: T) -> Self {
-        IntoInner {
+impl<T> End<T> {
+    fn new(err: sval::Error, stream: T) -> Self {
+        End {
             err,
-            value,
+            stream,
             _private: (),
         }
     }
 }
 
-impl<T> crate::std::fmt::Debug for IntoInner<T> {
+impl<T> crate::std::fmt::Debug for End<T> {
     fn fmt(&self, f: &mut crate::std::fmt::Formatter) -> crate::std::fmt::Result {
-        f.debug_struct("IntoInner").field("err", &self.err).finish()
+        f.debug_struct("End").field("err", &self.err).finish()
     }
 }
 
-impl<T> crate::std::fmt::Display for IntoInner<T> {
+impl<T> crate::std::fmt::Display for End<T> {
     fn fmt(&self, f: &mut crate::std::fmt::Formatter) -> crate::std::fmt::Result {
         write!(
             f,
-            "failed to take the inner json writer because it is invalid"
+            "failed to take the inner JSON writer because it is invalid"
         )
     }
 }

--- a/json/src/std_support.rs
+++ b/json/src/std_support.rs
@@ -13,10 +13,10 @@ use crate::{
         fmt,
         io::Write,
     },
-    IntoInner,
+    End,
 };
 
-impl<T> Error for IntoInner<T> {
+impl<T> Error for End<T> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         self.err.source()
     }
@@ -103,10 +103,10 @@ where
     If the writer contains incomplete json then this method will fail.
     The returned error can be used to pull the original stream back out.
     */
-    pub fn end(self) -> Result<W, IntoInner<Self>> {
+    pub fn end(self) -> Result<W, End<Self>> {
         match self.0.end() {
             Ok(w) => Ok(w.0),
-            Err(IntoInner { err, value, .. }) => Err(IntoInner::new(err, Writer(value))),
+            Err(End { err, stream, .. }) => Err(End::new(err, Writer(stream))),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval]
-version = "0.3.1"
+version = "0.4.0"
 ```
 
 # Supported formats
 
-- [JSON](https://crates.io/crates/sval_json)
+- [JSON](https://crates.io/crates/sval_json), the ubiquitous JavaScript Object Notation used by many HTTP APIs.
 
 # Streaming values
 
@@ -423,7 +423,7 @@ fn with_value(value: impl sval::Value) {
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/sval/0.4.0")]
 #![no_std]
 
 #[macro_use]

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -24,6 +24,13 @@ to have the same depth or greater.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Depth(usize);
 
+#[cfg(feature = "std")]
+impl Depth {
+    pub(crate) fn root() -> Self {
+        Depth(0)
+    }
+}
+
 impl Pos {
     /**
     Whether the current position is a map key.

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -49,11 +49,14 @@ impl OwnedValue {
 
     The given value doesn't need to be `Send + Sync + 'static`.
 
+    Some primitive types can be converted into an `OwnedValue`
+    for free. These types have a corresponding `From` implementation.
+
     The structure of the given value will be streamed into
-    a shared datastructure. That means this method is more
+    a sharable representation. That means this method is more
     expensive for more complex values.
 
-    Prefer the `from_shared` method where possible.
+    Prefer the `From` impls and `from_shared` method where possible.
 
     [`Value`]: struct.Value.html
     */
@@ -119,6 +122,159 @@ impl Debug for OwnedValue {
         {
             f.debug_struct("OwnedValue").finish()
         }
+    }
+}
+
+impl From<usize> for OwnedValue {
+    fn from(v: usize) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Unsigned(v as u64)
+        }))
+    }
+}
+
+impl From<u8> for OwnedValue {
+    fn from(v: u8) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Unsigned(v as u64)
+        }))
+    }
+}
+
+impl From<u16> for OwnedValue {
+    fn from(v: u16) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Unsigned(v as u64)
+        }))
+    }
+}
+
+impl From<u32> for OwnedValue {
+    fn from(v: u32) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Unsigned(v as u64)
+        }))
+    }
+}
+
+impl From<u64> for OwnedValue {
+    fn from(v: u64) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Unsigned(v)
+        }))
+    }
+}
+
+impl From<u128> for OwnedValue {
+    fn from(v: u128) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::BigUnsigned(v)
+        }))
+    }
+}
+
+impl From<isize> for OwnedValue {
+    fn from(v: isize) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Signed(v as i64)
+        }))
+    }
+}
+
+impl From<i8> for OwnedValue {
+    fn from(v: i8) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Signed(v as i64)
+        }))
+    }
+}
+
+impl From<i16> for OwnedValue {
+    fn from(v: i16) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Signed(v as i64)
+        }))
+    }
+}
+
+impl From<i32> for OwnedValue {
+    fn from(v: i32) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Signed(v as i64)
+        }))
+    }
+}
+
+impl From<i64> for OwnedValue {
+    fn from(v: i64) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Signed(v)
+        }))
+    }
+}
+
+impl From<i128> for OwnedValue {
+    fn from(v: i128) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::BigSigned(v)
+        }))
+    }
+}
+
+impl From<f32> for OwnedValue {
+    fn from(v: f32) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Float(v as f64)
+        }))
+    }
+}
+
+impl From<f64> for OwnedValue {
+    fn from(v: f64) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Float(v)
+        }))
+    }
+}
+
+impl From<bool> for OwnedValue {
+    fn from(v: bool) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Bool(v)
+        }))
+    }
+}
+
+impl From<char> for OwnedValue {
+    fn from(v: char) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Char(v)
+        }))
+    }
+}
+
+impl From<String> for OwnedValue {
+    fn from(v: String) -> Self {
+        OwnedValue(ValueInner::Primitive(Token {
+            depth: stack::Depth::root(),
+            kind: Kind::Str(v)
+        }))
     }
 }
 
@@ -201,7 +357,7 @@ impl Buf {
     }
 
     fn push(&mut self, kind: Kind, depth: stack::Depth) {
-        self.tokens.push(Token { depth: depth, kind });
+        self.tokens.push(Token { depth, kind });
     }
 }
 
@@ -363,7 +519,7 @@ impl Primitive {
     }
 
     fn set(&mut self, kind: Kind, depth: stack::Depth) {
-        self.token = Some(Token { depth: depth, kind });
+        self.token = Some(Token { depth, kind });
     }
 }
 


### PR DESCRIPTION
Ok, it looks like some links were broken. I also don't like that `sval_json::Writer::end` returns a type called `IntoInner` instead of a type called `End`. Renaming it is a breaking change, so I'll just roll that in to a `0.4.0` release.

Will this be the last release today?