### PR TITLE
Support serde integration in no-std environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,22 @@ language: rust
 matrix:
   include:
     - rust: nightly
+      env:
+      - LABEL="nightly"
       script:
       - ./ci/nightly.sh
     - rust: beta
+      env:
+      - LABEL="beta"
       script:
       - ./ci/beta.sh
     - rust: stable
+      env:
+      - LABEL="stable"
       script:
       - ./ci/stable.sh
     - rust: stable
+      env:
+      - LABEL="no-std"
       script:
       - ./ci/thumbv6m.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,9 @@ test = ["std"]
 fmt = []
 
 # Support integration with `serde`
-serde = ["std", "serde_lib/std"]
+serde = ["serde_std"]
+serde_std = ["std", "serde_lib/std"]
+serde_no_std = ["serde_lib"]
 
 [dependencies.smallvec]
 version = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "derive",
     "tests/serde",
+    "tests/serde_no_std",
     "tests/fmt",
 
     "json",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This library requires Rust `1.31.0`.
 - `std`: assume `std` is available and add support for `std` types.
 - `derive`: add support for `#[derive(Value)]`.
 - `serde`: enable integration with `serde`.
+    - `serde_std` (same as `serde`): enable `serde` integration along with `std`. This is for maximum ecosystem compatibility.
+    - `serde_no_std`: enable `serde` integration without needing `std`. Some implementations of `sval::Value` may not be representable. This is for specialized `no_std` use-cases.
 - `fmt`: support converting any `Value` into a `Debug`.
 - `arbitrary-depth`: support stateful values with any depth.
 - `test`: add helpers for testing implementations of `Value`.

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -15,6 +15,9 @@ cargo test --features fmt
 printf "\n\n---- sval with serde ----\n\n"
 cargo test --features serde
 
+printf "\n\n---- sval with serde_no_std ----\n\n"
+cargo test --features serde_no_std
+
 printf "\n\n---- sval with all features in release mode ----\n\n"
 cargo test --all-features --release
 
@@ -31,6 +34,6 @@ popd
 # Benches are checked in the `nightly` build
 # Format consistency is checked in the `beta` build
 printf "\n\n---- integration tests ----\n\n"
-cargo test --all \
-  --exclude sval_json_benches \
-  --exclude sval_fmt_tests
+cargo test --all --exclude sval_serde_no_std_tests --exclude sval_json_benches --exclude sval_fmt_tests
+
+cargo test -p sval_serde_no_std_tests

--- a/ci/thumbv6m.sh
+++ b/ci/thumbv6m.sh
@@ -11,6 +11,9 @@ cargo build --target=thumbv6m-none-eabi
 printf "\n\n---- sval with fmt ----\n\n"
 cargo build --target=thumbv6m-none-eabi --features fmt
 
+printf "\n\n---- sval with serde_no_std ----\n\n"
+cargo build --target=thumbv6m-none-eabi --features serde_no_std
+
 # sval_json builds
 pushd json
 printf "\n\n---- sval_json ----\n\n"

--- a/derive/src/value.rs
+++ b/derive/src/value.rs
@@ -41,7 +41,7 @@ pub(crate) fn derive_from_serde(input: DeriveInput) -> TokenStream {
             impl #impl_generics sval::Value for #ident #ty_generics #bounded_where_clause {
                 fn stream(&self, stream: &mut sval::value::Stream) -> Result<(), sval::value::Error> {
                     sval::derive_from_serde!(
-                        if #[cfg(feature = "serde")] {
+                        if #[cfg(feature = "serde_lib")] {
                             stream.any(sval::serde::to_value(self))
                         }
                         else {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,17 +1,17 @@
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_lib")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! derive_from_serde {
-    (if #[cfg(feature = "serde")] { $($with:tt)* } else { $($without:tt)* } ) => {
+    (if #[cfg(feature = "serde_lib")] { $($with:tt)* } else { $($without:tt)* } ) => {
         $($with)*
     };
 }
 
-#[cfg(not(feature = "serde"))]
+#[cfg(not(feature = "serde_lib"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! derive_from_serde {
-    (if #[cfg(feature = "serde")] { $($with:tt)* } else { $($without:tt)* } ) => {
+    (if #[cfg(feature = "serde_lib")] { $($with:tt)* } else { $($without:tt)* } ) => {
         $($without)*
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,14 @@ pub enum Data {
 # }
 ```
 
+In no-std environments, `serde` support can be enabled using the `serde_no_std` feature
+instead:
+
+```toml,ignore
+[dependencies.sval]
+features = ["serde_no_std"]
+```
+
 # `std::fmt` integration
 
 Use the `fmt` Cargo feature to enable extended integration with `std::fmt`:
@@ -454,7 +462,7 @@ pub mod test;
 #[cfg(feature = "fmt")]
 pub mod fmt;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_lib")]
 pub mod serde;
 
 pub mod stream;

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -35,19 +35,19 @@ pub(super) fn err<E>(msg: &'static str) -> impl FnOnce(E) -> crate::Error
 where
     E: ser::Error,
 {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "serde_std")]
     {
         let _ = msg;
         move |err| crate::Error::from(err)
     }
 
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(feature = "serde_std"))]
     {
         move |_| crate::Error::msg(msg)
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "serde_std"))]
 mod core_support {
     use super::*;
 
@@ -61,7 +61,7 @@ mod core_support {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde_std")]
 mod std_support {
     use super::*;
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -110,3 +110,11 @@ Stream a [`Serialize`] using the given [`Stream`].
 pub fn stream(stream: impl Stream, value: impl Serialize) -> Result<(), Error> {
     crate::stream(stream, to_value(value))
 }
+
+#[doc(hidden)]
+#[cfg(feature = "serde_std")]
+pub const IS_NO_STD: bool = false;
+
+#[doc(hidden)]
+#[cfg(not(feature = "serde_std"))]
+pub const IS_NO_STD: bool = true;

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -8,6 +8,14 @@ Add the `serde` feature to your `Cargo.toml` to enable this module:
 features = ["serde"]
 ```
 
+In no-std environments, `serde` support can be enabled using the `serde_no_std` feature
+instead:
+
+```toml,ignore
+[dependencies.sval]
+features = ["serde_no_std"]
+```
+
 # From `sval` to `serde`
 
 A type that implements [`sval::Value`](../value/trait.Value.html) can be converted into
@@ -24,6 +32,13 @@ a type that implements [`serde::Serialize`]:
 let my_serialize = sval::serde::to_serialize(my_value);
 ```
 
+When using `serde_no_std`, there are some limitations on what kinds of `sval::Value`s you
+can convert into `serde::Serialize`s:
+
+- Any type that uses [`value::Stream::map_key_begin`], [`value::Stream::map_value_begin`],
+or [`value::Stream::seq_elem_begin`] would require buffering, so will return an error instead
+in no-std environments.
+
 # From `serde` to `sval`
 
 A type that implements [`serde::Serialize`] can be converted into
@@ -39,6 +54,10 @@ a type that implements [`sval::Value`](../value/trait.Value.html):
 # let my_serialize = MySerialize;
 let my_value = sval::serde::to_value(my_serialize);
 ```
+
+[`value::Stream::map_key_begin`]: ../value/struct.Stream.html#method.map_key_begin
+[`value::Stream::map_value_begin`]: ../value/struct.Stream.html#method.map_value_begin
+[`value::Stream::seq_elem_begin`]: ../value/struct.Stream.html#method.seq_elem_begin
 */
 
 mod error;

--- a/src/serde/to_serialize.rs
+++ b/src/serde/to_serialize.rs
@@ -7,18 +7,8 @@ use crate::{
         cell::Cell,
         fmt,
     },
-    stream::{
-        self,
-        stack,
-        Stream as StreamTrait,
-    },
-    value::{
-        self,
-        owned::{
-            Buf,
-            Token,
-        },
-    },
+    stream,
+    value,
 };
 
 use super::error::err;
@@ -100,7 +90,8 @@ where
 {
     ok: Option<S::Ok>,
     pos: Option<Pos>,
-    buffered: Option<Buf>,
+    #[cfg(feature = "serde_std")]
+    buffered: Option<self::std_support::Buf>,
     current: Option<Current<S>>,
 }
 
@@ -122,6 +113,7 @@ where
         Stream {
             ok: None,
             pos: None,
+            #[cfg(feature = "serde_std")]
             buffered: None,
             current: Some(Current::Serializer(ser)),
         }
@@ -182,47 +174,6 @@ impl<S> Stream<S>
 where
     S: Serializer,
 {
-    /**
-    Begin a buffer with the given token or push it if a buffer already exists.
-    */
-    fn buffer_begin(&mut self) -> &mut Buf {
-        match self.buffered {
-            Some(ref mut buffered) => buffered,
-            None => {
-                self.buffered = Some(Buf::new());
-                self.buffered.as_mut().unwrap()
-            }
-        }
-    }
-
-    /**
-    End a buffer by serializing its contents.
-    */
-    fn buffer_end(&mut self) -> stream::Result {
-        if let Some(mut buffered) = self.buffered.take() {
-            let r = self.serialize_any(Tokens(buffered.tokens()));
-
-            buffered.clear();
-            self.buffered = Some(buffered);
-
-            return r;
-        }
-
-        Ok(())
-    }
-
-    /**
-    Get a reference to the buffer if it's active.
-    */
-    #[inline]
-    fn buffer(&mut self) -> Option<&mut Buf> {
-        match self.buffered {
-            None => None,
-            Some(ref mut buffered) if buffered.tokens().len() > 0 => Some(buffered),
-            _ => None,
-        }
-    }
-
     #[inline]
     fn take_current(&mut self) -> Current<S> {
         self.current
@@ -284,325 +235,538 @@ where
     }
 }
 
-impl<S> Collect for Stream<S>
-where
-    S: Serializer,
-{
-    #[inline]
-    fn map_key_collect(&mut self, k: collect::Value) -> collect::Result {
-        match self.buffer() {
-            None => self.serialize_key(ToSerialize(Value::new(k))),
-            Some(buffered) => {
-                buffered.map_key()?;
-                k.stream(collect::Default(buffered))
-            }
-        }
-    }
-
-    #[inline]
-    fn map_value_collect(&mut self, v: collect::Value) -> collect::Result {
-        match self.buffer() {
-            None => self.serialize_value(ToSerialize(Value::new(v))),
-            Some(buffered) => {
-                buffered.map_value()?;
-                v.stream(collect::Default(buffered))
-            }
-        }
-    }
-
-    #[inline]
-    fn seq_elem_collect(&mut self, v: collect::Value) -> collect::Result {
-        match self.buffer() {
-            None => self.serialize_elem(ToSerialize(Value::new(v))),
-            Some(buffered) => {
-                buffered.seq_elem()?;
-                v.stream(collect::Default(buffered))
-            }
-        }
-    }
-}
-
-impl<S> stream::Stream for Stream<S>
-where
-    S: Serializer,
-{
-    #[inline]
-    fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
-        match self.buffer() {
-            None => {
-                match self.take_current() {
-                    Current::Serializer(ser) => {
-                        let seq = ser.serialize_seq(len).map(Current::SerializeSeq)?;
-                        self.current = Some(seq);
-                    }
-                    current => {
-                        self.buffer_begin().seq_begin(len)?;
-
-                        self.current = Some(current);
-                    }
-                }
-
-                Ok(())
-            }
-            Some(buffered) => buffered.seq_begin(len),
-        }
-    }
-
-    #[inline]
-    fn seq_elem(&mut self) -> stream::Result {
-        match self.buffer() {
-            None => {
-                self.pos = Some(Pos::Elem);
-
-                Ok(())
-            }
-            Some(buffered) => buffered.seq_elem(),
-        }
-    }
-
-    #[inline]
-    fn seq_end(&mut self) -> stream::Result {
-        match self.buffer() {
-            None => {
-                let seq = self.take_current().take_serialize_seq();
-                self.ok = Some(seq.end().map_err(err("error completing sequence"))?);
-
-                Ok(())
-            }
-            Some(buffered) => {
-                buffered.seq_end()?;
-
-                if buffered.is_streamable() {
-                    self.buffer_end()?;
-                }
-
-                Ok(())
-            }
-        }
-    }
-
-    #[inline]
-    fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
-        match self.buffer() {
-            None => {
-                match self.take_current() {
-                    Current::Serializer(ser) => {
-                        let map = ser.serialize_map(len).map(Current::SerializeMap)?;
-                        self.current = Some(map);
-                    }
-                    current => {
-                        self.buffer_begin().map_begin(len)?;
-                        self.current = Some(current);
-                    }
-                }
-
-                Ok(())
-            }
-            Some(buffered) => buffered.map_begin(len),
-        }
-    }
-
-    #[inline]
-    fn map_key(&mut self) -> stream::Result {
-        match self.buffer() {
-            None => {
-                self.pos = Some(Pos::Key);
-
-                Ok(())
-            }
-            Some(buffered) => buffered.map_key(),
-        }
-    }
-
-    #[inline]
-    fn map_value(&mut self) -> stream::Result {
-        match self.buffer() {
-            None => {
-                self.pos = Some(Pos::Value);
-
-                Ok(())
-            }
-            Some(buffered) => buffered.map_value(),
-        }
-    }
-
-    #[inline]
-    fn map_end(&mut self) -> stream::Result {
-        match self.buffer() {
-            None => {
-                let map = self.take_current().take_serialize_map();
-                self.ok = Some(map.end().map_err(err("error completing map"))?);
-
-                Ok(())
-            }
-            Some(buffered) => {
-                buffered.map_end()?;
-
-                if buffered.is_streamable() {
-                    self.buffer_end()?;
-                }
-
-                Ok(())
-            }
-        }
-    }
-
-    #[inline]
-    fn i64(&mut self, v: i64) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.i64(v),
-        }
-    }
-
-    #[inline]
-    fn u64(&mut self, v: u64) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.u64(v),
-        }
-    }
-
-    #[inline]
-    fn i128(&mut self, v: i128) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.i128(v),
-        }
-    }
-
-    #[inline]
-    fn u128(&mut self, v: u128) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.u128(v),
-        }
-    }
-
-    #[inline]
-    fn f64(&mut self, v: f64) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.f64(v),
-        }
-    }
-
-    #[inline]
-    fn bool(&mut self, v: bool) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.bool(v),
-        }
-    }
-
-    #[inline]
-    fn char(&mut self, v: char) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.char(v),
-        }
-    }
-
-    #[inline]
-    fn str(&mut self, v: &str) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.str(v),
-        }
-    }
-
-    #[inline]
-    fn none(&mut self) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(Option::None::<()>),
-            Some(buffered) => buffered.none(),
-        }
-    }
-
-    #[inline]
-    fn fmt(&mut self, v: fmt::Arguments) -> stream::Result {
-        match self.buffer() {
-            None => self.serialize_any(v),
-            Some(buffered) => buffered.fmt(v),
-        }
-    }
-}
-
 enum Pos {
     Key,
     Value,
     Elem,
 }
 
-struct Tokens<'a>(&'a [Token]);
+#[cfg(not(feature = "serde_std"))]
+mod no_std_support {
+    use super::*;
 
-struct TokensReader<'a> {
-    idx: usize,
-    tokens: &'a [Token],
-}
-
-impl<'a> Tokens<'a> {
-    #[inline]
-    fn reader(&self) -> TokensReader<'a> {
-        TokensReader {
-            idx: 0,
-            tokens: self.0,
-        }
-    }
-}
-
-impl<'a> TokensReader<'a> {
-    fn next_serializable(&mut self, depth: stack::Depth) -> Tokens<'a> {
-        let start = self.idx;
-
-        let take = self.tokens[self.idx..]
-            .iter()
-            .enumerate()
-            .take_while(|(_, t)| t.depth > depth)
-            .fuse()
-            .last()
-            .map(|(idx, _)| idx + 1)
-            .unwrap_or(1);
-
-        self.idx += take;
-
-        Tokens(&self.tokens[start..self.idx])
-    }
-
-    #[inline]
-    fn expect_empty(&self) -> stream::Result {
-        if self.idx < self.tokens.len() {
-            Err(stream::Error::msg("unexpected trailing tokens"))
-        } else {
-            Ok(())
-        }
-    }
-}
-
-impl<'a> Iterator for TokensReader<'a> {
-    type Item = &'a Token;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let idx = self.idx;
-        self.idx += 1;
-
-        self.tokens.get(idx)
-    }
-}
-
-impl<'a> Serialize for Tokens<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    impl<S> Collect for Stream<S>
     where
         S: Serializer,
     {
-        use self::value::owned::Kind;
+        #[inline]
+        fn map_key_collect(&mut self, k: collect::Value) -> collect::Result {
+            self.serialize_key(ToSerialize(Value::new(k)))
+        }
 
-        let mut reader = self.reader();
+        #[inline]
+        fn map_value_collect(&mut self, v: collect::Value) -> collect::Result {
+            self.serialize_value(ToSerialize(Value::new(v)))
+        }
 
-        match reader.next() {
-            None => serializer.serialize_none(),
-            Some(token) => {
-                match token.kind {
+        #[inline]
+        fn seq_elem_collect(&mut self, v: collect::Value) -> collect::Result {
+            self.serialize_elem(ToSerialize(Value::new(v)))
+        }
+    }
+
+    impl<S> stream::Stream for Stream<S>
+    where
+        S: Serializer,
+    {
+        #[inline]
+        fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
+            match self.take_current() {
+                Current::Serializer(ser) => {
+                    let seq = ser
+                        .serialize_seq(len)
+                        .map(Current::SerializeSeq)
+                        .map_err(err("error beginning sequence"))?;
+                    self.current = Some(seq);
+
+                    Ok(())
+                }
+                _ => Err(stream::Error::msg(
+                    "unsupported value type requires buffering",
+                )),
+            }
+        }
+
+        #[inline]
+        fn seq_elem(&mut self) -> stream::Result {
+            self.pos = Some(Pos::Elem);
+
+            Ok(())
+        }
+
+        #[inline]
+        fn seq_end(&mut self) -> stream::Result {
+            let seq = self.take_current().take_serialize_seq();
+            self.ok = Some(seq.end().map_err(err("error completing sequence"))?);
+
+            Ok(())
+        }
+
+        #[inline]
+        fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
+            match self.take_current() {
+                Current::Serializer(ser) => {
+                    let map = ser
+                        .serialize_map(len)
+                        .map(Current::SerializeMap)
+                        .map_err(err("error beginning map"))?;
+                    self.current = Some(map);
+
+                    Ok(())
+                }
+                _ => Err(stream::Error::msg(
+                    "unsupported value type requires buffering",
+                )),
+            }
+        }
+
+        #[inline]
+        fn map_key(&mut self) -> stream::Result {
+            self.pos = Some(Pos::Key);
+
+            Ok(())
+        }
+
+        #[inline]
+        fn map_value(&mut self) -> stream::Result {
+            self.pos = Some(Pos::Value);
+
+            Ok(())
+        }
+
+        #[inline]
+        fn map_end(&mut self) -> stream::Result {
+            let map = self.take_current().take_serialize_map();
+            self.ok = Some(map.end().map_err(err("error completing map"))?);
+
+            Ok(())
+        }
+
+        #[inline]
+        fn i64(&mut self, v: i64) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn u64(&mut self, v: u64) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn i128(&mut self, v: i128) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn u128(&mut self, v: u128) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn f64(&mut self, v: f64) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn bool(&mut self, v: bool) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn char(&mut self, v: char) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn str(&mut self, v: &str) -> stream::Result {
+            self.serialize_any(v)
+        }
+
+        #[inline]
+        fn none(&mut self) -> stream::Result {
+            self.serialize_any(Option::None::<()>)
+        }
+
+        #[inline]
+        fn fmt(&mut self, v: fmt::Arguments) -> stream::Result {
+            self.serialize_any(v)
+        }
+    }
+}
+
+#[cfg(feature = "serde_std")]
+mod std_support {
+    use super::*;
+
+    use crate::stream::{
+        self,
+        stack,
+        Stream as StreamTrait,
+    };
+
+    pub(super) use crate::value::owned::{
+        Buf,
+        Token,
+    };
+
+    impl<S> Stream<S>
+    where
+        S: Serializer,
+    {
+        /**
+        Begin a buffer with the given token or push it if a buffer already exists.
+        */
+        fn buffer_begin(&mut self) -> &mut Buf {
+            match self.buffered {
+                Some(ref mut buffered) => buffered,
+                None => {
+                    self.buffered = Some(Buf::new());
+                    self.buffered.as_mut().unwrap()
+                }
+            }
+        }
+
+        /**
+        End a buffer by serializing its contents.
+        */
+        fn buffer_end(&mut self) -> stream::Result {
+            if let Some(mut buffered) = self.buffered.take() {
+                let r = self.serialize_any(Tokens(buffered.tokens()));
+
+                buffered.clear();
+                self.buffered = Some(buffered);
+
+                return r;
+            }
+
+            Ok(())
+        }
+
+        /**
+        Get a reference to the buffer if it's active.
+        */
+        #[inline]
+        fn buffer(&mut self) -> Option<&mut Buf> {
+            match self.buffered {
+                None => None,
+                Some(ref mut buffered) if buffered.tokens().len() > 0 => Some(buffered),
+                _ => None,
+            }
+        }
+    }
+
+    impl<S> Collect for Stream<S>
+    where
+        S: Serializer,
+    {
+        #[inline]
+        fn map_key_collect(&mut self, k: collect::Value) -> collect::Result {
+            match self.buffer() {
+                None => self.serialize_key(ToSerialize(Value::new(k))),
+                Some(buffered) => {
+                    buffered.map_key()?;
+                    k.stream(collect::Default(buffered))
+                }
+            }
+        }
+
+        #[inline]
+        fn map_value_collect(&mut self, v: collect::Value) -> collect::Result {
+            match self.buffer() {
+                None => self.serialize_value(ToSerialize(Value::new(v))),
+                Some(buffered) => {
+                    buffered.map_value()?;
+                    v.stream(collect::Default(buffered))
+                }
+            }
+        }
+
+        #[inline]
+        fn seq_elem_collect(&mut self, v: collect::Value) -> collect::Result {
+            match self.buffer() {
+                None => self.serialize_elem(ToSerialize(Value::new(v))),
+                Some(buffered) => {
+                    buffered.seq_elem()?;
+                    v.stream(collect::Default(buffered))
+                }
+            }
+        }
+    }
+
+    impl<S> stream::Stream for Stream<S>
+    where
+        S: Serializer,
+    {
+        #[inline]
+        fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
+            match self.buffer() {
+                None => {
+                    match self.take_current() {
+                        Current::Serializer(ser) => {
+                            let seq = ser.serialize_seq(len).map(Current::SerializeSeq)?;
+                            self.current = Some(seq);
+                        }
+                        current => {
+                            self.buffer_begin().seq_begin(len)?;
+
+                            self.current = Some(current);
+                        }
+                    }
+
+                    Ok(())
+                }
+                Some(buffered) => buffered.seq_begin(len),
+            }
+        }
+
+        #[inline]
+        fn seq_elem(&mut self) -> stream::Result {
+            match self.buffer() {
+                None => {
+                    self.pos = Some(Pos::Elem);
+
+                    Ok(())
+                }
+                Some(buffered) => buffered.seq_elem(),
+            }
+        }
+
+        #[inline]
+        fn seq_end(&mut self) -> stream::Result {
+            match self.buffer() {
+                None => {
+                    let seq = self.take_current().take_serialize_seq();
+                    self.ok = Some(seq.end().map_err(err("error completing sequence"))?);
+
+                    Ok(())
+                }
+                Some(buffered) => {
+                    buffered.seq_end()?;
+
+                    if buffered.is_streamable() {
+                        self.buffer_end()?;
+                    }
+
+                    Ok(())
+                }
+            }
+        }
+
+        #[inline]
+        fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
+            match self.buffer() {
+                None => {
+                    match self.take_current() {
+                        Current::Serializer(ser) => {
+                            let map = ser.serialize_map(len).map(Current::SerializeMap)?;
+                            self.current = Some(map);
+                        }
+                        current => {
+                            self.buffer_begin().map_begin(len)?;
+                            self.current = Some(current);
+                        }
+                    }
+
+                    Ok(())
+                }
+                Some(buffered) => buffered.map_begin(len),
+            }
+        }
+
+        #[inline]
+        fn map_key(&mut self) -> stream::Result {
+            match self.buffer() {
+                None => {
+                    self.pos = Some(Pos::Key);
+
+                    Ok(())
+                }
+                Some(buffered) => buffered.map_key(),
+            }
+        }
+
+        #[inline]
+        fn map_value(&mut self) -> stream::Result {
+            match self.buffer() {
+                None => {
+                    self.pos = Some(Pos::Value);
+
+                    Ok(())
+                }
+                Some(buffered) => buffered.map_value(),
+            }
+        }
+
+        #[inline]
+        fn map_end(&mut self) -> stream::Result {
+            match self.buffer() {
+                None => {
+                    let map = self.take_current().take_serialize_map();
+                    self.ok = Some(map.end().map_err(err("error completing map"))?);
+
+                    Ok(())
+                }
+                Some(buffered) => {
+                    buffered.map_end()?;
+
+                    if buffered.is_streamable() {
+                        self.buffer_end()?;
+                    }
+
+                    Ok(())
+                }
+            }
+        }
+
+        #[inline]
+        fn i64(&mut self, v: i64) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.i64(v),
+            }
+        }
+
+        #[inline]
+        fn u64(&mut self, v: u64) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.u64(v),
+            }
+        }
+
+        #[inline]
+        fn i128(&mut self, v: i128) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.i128(v),
+            }
+        }
+
+        #[inline]
+        fn u128(&mut self, v: u128) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.u128(v),
+            }
+        }
+
+        #[inline]
+        fn f64(&mut self, v: f64) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.f64(v),
+            }
+        }
+
+        #[inline]
+        fn bool(&mut self, v: bool) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.bool(v),
+            }
+        }
+
+        #[inline]
+        fn char(&mut self, v: char) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.char(v),
+            }
+        }
+
+        #[inline]
+        fn str(&mut self, v: &str) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.str(v),
+            }
+        }
+
+        #[inline]
+        fn none(&mut self) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(Option::None::<()>),
+                Some(buffered) => buffered.none(),
+            }
+        }
+
+        #[inline]
+        fn fmt(&mut self, v: fmt::Arguments) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v),
+                Some(buffered) => buffered.fmt(v),
+            }
+        }
+    }
+
+    struct Tokens<'a>(&'a [Token]);
+
+    struct TokensReader<'a> {
+        idx: usize,
+        tokens: &'a [Token],
+    }
+
+    impl<'a> Tokens<'a> {
+        #[inline]
+        fn reader(&self) -> TokensReader<'a> {
+            TokensReader {
+                idx: 0,
+                tokens: self.0,
+            }
+        }
+    }
+
+    impl<'a> TokensReader<'a> {
+        fn next_serializable(&mut self, depth: stack::Depth) -> Tokens<'a> {
+            let start = self.idx;
+
+            let take = self.tokens[self.idx..]
+                .iter()
+                .enumerate()
+                .take_while(|(_, t)| t.depth > depth)
+                .fuse()
+                .last()
+                .map(|(idx, _)| idx + 1)
+                .unwrap_or(1);
+
+            self.idx += take;
+
+            Tokens(&self.tokens[start..self.idx])
+        }
+
+        #[inline]
+        fn expect_empty(&self) -> stream::Result {
+            if self.idx < self.tokens.len() {
+                Err(stream::Error::msg("unexpected trailing tokens"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl<'a> Iterator for TokensReader<'a> {
+        type Item = &'a Token;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let idx = self.idx;
+            self.idx += 1;
+
+            self.tokens.get(idx)
+        }
+    }
+
+    impl<'a> Serialize for Tokens<'a> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            use self::value::owned::Kind;
+
+            let mut reader = self.reader();
+
+            match reader.next() {
+                None => serializer.serialize_none(),
+                Some(token) => match token.kind {
                     Kind::Signed(v) => {
                         reader.expect_empty().map_err(S::Error::custom)?;
 
@@ -700,7 +864,7 @@ impl<'a> Serialize for Tokens<'a> {
                     _ => Err(S::Error::custom(
                         "unexpected token value (expected a primitive, map, or sequence)",
                     )),
-                }
+                },
             }
         }
     }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -633,7 +633,7 @@ impl Stream for Primitive {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_std")]
 impl Buf {
     pub(crate) fn clear(&mut self) {
         self.tokens.clear();

--- a/tests/serde_no_std/Cargo.toml
+++ b/tests/serde_no_std/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sval_serde_tests"
+name = "sval_serde_no_std_tests"
 version = "0.0.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
@@ -10,11 +10,8 @@ path = "lib.rs"
 
 [dependencies.sval]
 path = "../../"
-features = ["derive", "test", "serde"]
+features = ["derive", "serde_no_std", "test"]
 
 [dependencies.serde]
 version = "1"
-features = ["derive"]
-
-[dependencies.serde_test]
-version = "1"
+default-features = false

--- a/tests/serde_no_std/lib.rs
+++ b/tests/serde_no_std/lib.rs
@@ -1,0 +1,99 @@
+#![cfg(test)]
+
+#[macro_use]
+extern crate sval;
+
+use sval::{
+    test::Token,
+    value::{
+        self,
+        Value,
+    },
+};
+
+#[derive(Value)]
+struct Struct<'a> {
+    a: i32,
+    b: i32,
+    #[sval(rename = "renamed")]
+    c: Nested<'a>,
+}
+
+#[derive(Value)]
+struct Nested<'a> {
+    a: i32,
+    b: &'a str,
+}
+
+struct Anonymous;
+
+impl Value for Anonymous {
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
+        stream.map_begin(None)?;
+
+        stream.map_key_begin()?.i64(1)?;
+
+        stream.map_value_begin()?.map_begin(None)?;
+
+        stream.map_key(2)?;
+
+        stream.map_value_begin()?.seq_begin(None)?;
+
+        stream.seq_elem_begin()?.i64(3)?;
+
+        stream.seq_end()?;
+
+        stream.map_end()?;
+
+        stream.map_key(11)?;
+
+        stream.map_value(111)?;
+
+        stream.map_end()
+    }
+}
+
+#[test]
+fn is_no_std() {
+    assert!(sval::serde::IS_NO_STD);
+}
+
+#[test]
+fn sval_derive() {
+    let ser = sval::serde::to_serialize(Struct {
+        a: 1,
+        b: 2,
+        c: Nested { a: 3, b: "Hello!" },
+    });
+
+    let v = sval::test::tokens(sval::serde::to_value(ser));
+    assert_eq!(
+        vec![
+            Token::MapBegin(Some(3)),
+            Token::Str(String::from("a")),
+            Token::Signed(1),
+            Token::Str(String::from("b")),
+            Token::Signed(2),
+            Token::Str(String::from("renamed")),
+            Token::MapBegin(Some(2)),
+            Token::Str(String::from("a")),
+            Token::Signed(3),
+            Token::Str(String::from("b")),
+            Token::Str(String::from("Hello!")),
+            Token::MapEnd,
+            Token::MapEnd,
+        ],
+        v
+    );
+}
+
+#[test]
+#[should_panic]
+fn sval_to_serde_anonymous() {
+    let ser = sval::serde::to_serialize(Anonymous);
+
+    // The anonymous map isn't supported in no-std
+    sval::test::tokens(sval::serde::to_value(ser));
+}
+
+


### PR DESCRIPTION
This is a spike that makes the `serde` integration of `sval` no-std compatible, so you could reasonably erase a `serde::Serialize` as a `sval::Value` in environments where you couldn't use `erased-serde`. There are some drawbacks though:

- Implementations that require buffering aren't supported in no-std. That includes the enum types in `serde`'s data model if they're capturing using `sval::serde::to_value`. We could work around this one by adding limited support buffered types that only have a single key/value/element.
- The representation of the `serde::Serialize` you get back out is not necessarily the same as the `serde::Serialize` you put in.

That means you're probably better off preferring `erased-serde` if it's available, but this is an option that might be good enough.

I need to figure out how to test the no-std implementation without depending on `serde-test`, since we need the `serde` we pull in not to have default features.