### PR TITLE
Add Error::unsupported variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,21 @@ impl Error {
         Error(ErrorInner::Static(msg))
     }
 
+    /** Declare some structure as unsupported. */
+    #[inline]
+    pub fn unsupported(operation: &'static str) -> Self {
+        Error(ErrorInner::Unsupported(operation))
+    }
+
+    /** Whether or not an error is because some operation was unsupported. */
+    pub fn is_unsupported(&self) -> bool {
+        if let ErrorInner::Unsupported(_) = self.0 {
+            true
+        } else {
+            false
+        }
+    }
+
     // NOTE: This method is not public because we already
     // have a method called `custom` when `std` is available.
     // It's strictly more general than this one, but could
@@ -46,6 +61,7 @@ impl fmt::Display for Error {
 
 #[derive(Clone)]
 enum ErrorInner {
+    Unsupported(&'static str),
     Static(&'static str),
     #[cfg(not(feature = "std"))]
     Custom(&'static dyn fmt::Display),
@@ -56,6 +72,7 @@ enum ErrorInner {
 impl fmt::Debug for ErrorInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            ErrorInner::Unsupported(op) => write!(f, "unsupported stream operation: {}", op),
             ErrorInner::Static(msg) => msg.fmt(f),
             #[cfg(not(feature = "std"))]
             ErrorInner::Custom(ref err) => err.fmt(f),
@@ -68,6 +85,7 @@ impl fmt::Debug for ErrorInner {
 impl fmt::Display for ErrorInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            ErrorInner::Unsupported(op) => write!(f, "unsupported stream operation: {}", op),
             ErrorInner::Static(msg) => msg.fmt(f),
             #[cfg(not(feature = "std"))]
             ErrorInner::Custom(ref err) => err.fmt(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,10 +270,6 @@ impl Stream for IsU64 {
 
         Ok(())
     }
-
-    fn fmt(&mut self, _: stream::Arguments) -> stream::Result {
-        Err(stream::Error::msg("not a u64"))
-    }
 }
 ```
 
@@ -315,6 +311,30 @@ impl Stream for Fmt {
         print!("{}{:?}", delim, v);
 
         Ok(())
+    }
+
+    fn i128(&mut self, v: i128) -> stream::Result {
+        self.fmt(format_args!("{:?}", v))
+    }
+
+    fn u128(&mut self, v: u128) -> stream::Result {
+        self.fmt(format_args!("{:?}", v))
+    }
+
+    fn f64(&mut self, v: f64) -> stream::Result {
+        self.fmt(format_args!("{:?}", v))
+    }
+
+    fn bool(&mut self, v: bool) -> stream::Result {
+        self.fmt(format_args!("{:?}", v))
+    }
+
+    fn str(&mut self, v: &str) -> stream::Result {
+        self.fmt(format_args!("{:?}", v))
+    }
+
+    fn none(&mut self) -> stream::Result {
+        self.fmt(format_args!("{:?}", ()))
     }
 
     fn seq_begin(&mut self, _: Option<usize>) -> stream::Result {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -34,48 +34,55 @@ pub trait Stream {
     /**
     Stream a format.
     */
-    fn fmt(&mut self, args: Arguments) -> Result;
+    fn fmt(&mut self, args: Arguments) -> Result {
+        let _ = args;
+        Err(Error::unsupported("Stream::fmt"))
+    }
 
     /**
     Stream a signed integer.
     */
     fn i64(&mut self, v: i64) -> Result {
-        self.fmt(format_args!("{:?}", v))
+        self.i128(v as i128)
     }
 
     /**
     Stream an unsigned integer.
     */
     fn u64(&mut self, v: u64) -> Result {
-        self.fmt(format_args!("{:?}", v))
+        self.u128(v as u128)
     }
 
     /**
     Stream a 128bit signed integer.
     */
     fn i128(&mut self, v: i128) -> Result {
-        self.fmt(format_args!("{:?}", v))
+        let _ = v;
+        Err(Error::unsupported("Stream::i128"))
     }
 
     /**
     Stream a 128bit unsigned integer.
     */
     fn u128(&mut self, v: u128) -> Result {
-        self.fmt(format_args!("{:?}", v))
+        let _ = v;
+        Err(Error::unsupported("Stream::u128"))
     }
 
     /**
     Stream a floating point value.
     */
     fn f64(&mut self, v: f64) -> Result {
-        self.fmt(format_args!("{:?}", v))
+        let _ = v;
+        Err(Error::unsupported("Stream::f64"))
     }
 
     /**
     Stream a boolean.
     */
     fn bool(&mut self, v: bool) -> Result {
-        self.fmt(format_args!("{:?}", v))
+        let _ = v;
+        Err(Error::unsupported("Stream::bool"))
     }
 
     /**
@@ -90,14 +97,15 @@ pub trait Stream {
     Stream a UTF-8 string slice.
     */
     fn str(&mut self, v: &str) -> Result {
-        self.fmt(format_args!("{:?}", v))
+        let _ = v;
+        Err(Error::unsupported("Stream::str"))
     }
 
     /**
     Stream an empty value.
     */
     fn none(&mut self) -> Result {
-        self.fmt(format_args!("{:?}", ()))
+        Err(Error::unsupported("Stream::none"))
     }
 
     /**
@@ -105,7 +113,7 @@ pub trait Stream {
     */
     fn map_begin(&mut self, len: Option<usize>) -> Result {
         let _ = len;
-        Ok(())
+        Err(Error::unsupported("Stream::map_begin"))
     }
 
     /**
@@ -114,7 +122,7 @@ pub trait Stream {
     The key will be implicitly ended by the stream methods that follow it.
     */
     fn map_key(&mut self) -> Result {
-        Ok(())
+        Err(Error::unsupported("Stream::map_key"))
     }
 
     /**
@@ -123,14 +131,14 @@ pub trait Stream {
     The value will be implicitly ended by the stream methods that follow it.
     */
     fn map_value(&mut self) -> Result {
-        Ok(())
+        Err(Error::unsupported("Stream::map_value"))
     }
 
     /**
     End a map.
     */
     fn map_end(&mut self) -> Result {
-        Ok(())
+        Err(Error::unsupported("Stream::map_end"))
     }
 
     /**
@@ -138,7 +146,7 @@ pub trait Stream {
     */
     fn seq_begin(&mut self, len: Option<usize>) -> Result {
         let _ = len;
-        Ok(())
+        Err(Error::unsupported("Stream::seq_begin"))
     }
 
     /**
@@ -147,14 +155,14 @@ pub trait Stream {
     The element will be implicitly ended by the stream methods that follow it.
     */
     fn seq_elem(&mut self) -> Result {
-        Ok(())
+        Err(Error::unsupported("Stream::seq_elem"))
     }
 
     /**
     End a sequence.
     */
     fn seq_end(&mut self) -> Result {
-        Ok(())
+        Err(Error::unsupported("Stream::seq_end"))
     }
 }
 


### PR DESCRIPTION
Closes #58 

Adds a `Error::unsupported` method that can be used to signal some structure is not supported by the current `Stream`.

The changes to the default implementations of `Stream` to return `Err(unsupported)` instead of `Ok(())` are technically a breaking _behavioural_ change (they won't break builds), but since the previous default implementation is entirely useless (so any implementation of `Stream` would override them anyways) I'll push it through.