### PR TITLE
Prepare for 0.4.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "sval"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval"
@@ -65,7 +65,7 @@ default-features = false
 package = "serde"
 
 [dependencies.sval_derive]
-version = "0.4.2"
+version = "0.4.3"
 path = "./derive"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add `sval` to your crate dependencies:
 
 ```toml
 [dependencies.sval]
-version = "0.4.2"
+version = "0.4.3"
 ```
 
 ## To support my data-structures
@@ -90,7 +90,7 @@ The `sval_json` crate can format any `sval::Value` as JSON:
 
 ```toml
 [dependencies.sval_json]
-version = "0.4.2"
+version = "0.4.3"
 features = ["std"]
 ```
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_derive"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,7 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_derive/0.4.2")]
+#![doc(html_root_url = "https://docs.rs/sval_derive/0.4.3")]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -31,3 +31,4 @@ version = "1"
 [dependencies.itoa]
 version = "0.4"
 features = ["i128"]
+default-features = false

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_json"
@@ -22,7 +22,7 @@ travis-ci = { repository = "KodrAus/sval" }
 std = ["sval/std"]
 
 [dependencies.sval]
-version = "0.4.2"
+version = "0.4.3"
 path = "../"
 
 [dependencies.ryu]
@@ -30,4 +30,4 @@ version = "1"
 
 [dependencies.itoa]
 version = "0.4"
-default-features = false
+features = ["i128"]

--- a/json/README.md
+++ b/json/README.md
@@ -25,7 +25,7 @@ Add `sval_json` to your crate dependencies:
 
 ```toml
 [dependencies.sval_json]
-version = "0.4.2"
+version = "0.4.3"
 ```
 
 ## To write JSON to a `fmt::Write`

--- a/json/src/fmt.rs
+++ b/json/src/fmt.rs
@@ -133,7 +133,7 @@ where
     }
 
     #[inline]
-    fn i64(&mut self, v: i64) -> stream::Result {
+    fn i128(&mut self, v: i128) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {
@@ -152,7 +152,7 @@ where
     }
 
     #[inline]
-    fn u64(&mut self, v: u64) -> stream::Result {
+    fn u128(&mut self, v: u128) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         if pos.is_key() {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -10,7 +10,7 @@ Add `sval_json` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval_json]
-version = "0.4.2"
+version = "0.4.3"
 ```
 
 # Writing JSON to `fmt::Write`
@@ -79,7 +79,7 @@ let json = sval_json::to_writer(MyWrite, 42)?;
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_json/0.4.2")]
+#![doc(html_root_url = "https://docs.rs/sval_json/0.4.3")]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval]
-version = "0.4.2"
+version = "0.4.3"
 ```
 
 # Supported formats
@@ -451,7 +451,7 @@ fn with_value(value: impl sval::Value) {
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval/0.4.2")]
+#![doc(html_root_url = "https://docs.rs/sval/0.4.3")]
 #![no_std]
 
 #[doc(hidden)]


### PR DESCRIPTION
Also fixes an issue in `sval_json` where we don't actually support 128bit integers properly.