### PR TITLE
Prepare for 0.4.5 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "sval"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval"
@@ -66,7 +66,7 @@ default-features = false
 package = "serde"
 
 [dependencies.sval_derive]
-version = "0.4.4"
+version = "0.4.5"
 path = "./derive"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add `sval` to your crate dependencies:
 
 ```toml
 [dependencies.sval]
-version = "0.4.4"
+version = "0.4.5"
 ```
 
 ## To support my data-structures
@@ -90,7 +90,7 @@ The `sval_json` crate can format any `sval::Value` as JSON:
 
 ```toml
 [dependencies.sval_json]
-version = "0.4.4"
+version = "0.4.5"
 features = ["std"]
 ```
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_derive"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,7 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_derive/0.4.4")]
+#![doc(html_root_url = "https://docs.rs/sval_derive/0.4.5")]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_json"
@@ -22,7 +22,7 @@ travis-ci = { repository = "KodrAus/sval" }
 std = ["sval/std"]
 
 [dependencies.sval]
-version = "0.4.4"
+version = "0.4.5"
 path = "../"
 
 [dependencies.ryu]

--- a/json/README.md
+++ b/json/README.md
@@ -25,7 +25,7 @@ Add `sval_json` to your crate dependencies:
 
 ```toml
 [dependencies.sval_json]
-version = "0.4.4"
+version = "0.4.5"
 ```
 
 ## To write JSON to a `fmt::Write`

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -10,7 +10,7 @@ Add `sval_json` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval_json]
-version = "0.4.4"
+version = "0.4.5"
 ```
 
 # Writing JSON to `fmt::Write`
@@ -79,7 +79,7 @@ let json = sval_json::to_writer(MyWrite, 42)?;
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_json/0.4.4")]
+#![doc(html_root_url = "https://docs.rs/sval_json/0.4.5")]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval]
-version = "0.4.4"
+version = "0.4.5"
 ```
 
 # Supported formats
@@ -165,7 +165,7 @@ fn with_value(value: impl sval::Value) {
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval/0.4.4")]
+#![doc(html_root_url = "https://docs.rs/sval/0.4.5")]
 #![no_std]
 
 #[doc(hidden)]

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -2,6 +2,18 @@
 A fixed-size, stateful stack for streams.
 */
 
+/*
+/!\ CAREFUL /!\
+
+This module contains unsafe code with some tricky
+invariants based on the state of the current slot.
+
+We use a combination of property-based testing
+and a reasonable test suite to try ensure safety
+is maintained, but any changes here should be
+reviewed carefully.
+*/
+
 use crate::std::fmt;
 
 use super::Error;


### PR DESCRIPTION
Also adds a note to the `stack` module about its use of `unsafe`.