### PR TITLE
Add Stream impls for more crate types

### DIFF
--- a/src/stream/owned.rs
+++ b/src/stream/owned.rs
@@ -239,6 +239,96 @@ where
     }
 }
 
+impl<S> Stream for OwnedStream<S>
+where
+    S: Stream,
+{
+    #[inline]
+    fn fmt(&mut self, args: Arguments) -> stream::Result {
+        self.fmt(args)
+    }
+
+    #[inline]
+    fn i64(&mut self, v: i64) -> stream::Result {
+        self.i64(v)
+    }
+
+    #[inline]
+    fn u64(&mut self, v: u64) -> stream::Result {
+        self.u64(v)
+    }
+
+    #[inline]
+    fn i128(&mut self, v: i128) -> stream::Result {
+        self.i128(v)
+    }
+
+    #[inline]
+    fn u128(&mut self, v: u128) -> stream::Result {
+        self.u128(v)
+    }
+
+    #[inline]
+    fn f64(&mut self, v: f64) -> stream::Result {
+        self.f64(v)
+    }
+
+    #[inline]
+    fn bool(&mut self, v: bool) -> stream::Result {
+        self.bool(v)
+    }
+
+    #[inline]
+    fn char(&mut self, v: char) -> stream::Result {
+        self.char(v)
+    }
+
+    #[inline]
+    fn str(&mut self, v: &str) -> stream::Result {
+        self.str(v)
+    }
+
+    #[inline]
+    fn none(&mut self) -> stream::Result {
+        self.none()
+    }
+
+    #[inline]
+    fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
+        self.map_begin(len)
+    }
+
+    #[inline]
+    fn map_key(&mut self) -> stream::Result {
+        self.map_key_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn map_value(&mut self) -> stream::Result {
+        self.map_value_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn map_end(&mut self) -> stream::Result {
+        self.map_end()
+    }
+
+    #[inline]
+    fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
+        self.seq_begin(len)
+    }
+
+    #[inline]
+    fn seq_elem(&mut self) -> stream::Result {
+        self.seq_elem_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn seq_end(&mut self) -> stream::Result {
+        self.seq_end()
+    }
+}
+
 /**
 A borrowed stream wrapper.
 
@@ -426,5 +516,145 @@ impl<'a> RefMutStream<'a> {
         self.0.seq_elem_begin()?;
 
         Ok(self)
+    }
+}
+
+impl<'a> Stream for RefMutStream<'a> {
+    #[inline]
+    fn fmt(&mut self, args: Arguments) -> stream::Result {
+        self.fmt(args)
+    }
+
+    #[inline]
+    fn i64(&mut self, v: i64) -> stream::Result {
+        self.i64(v)
+    }
+
+    #[inline]
+    fn u64(&mut self, v: u64) -> stream::Result {
+        self.u64(v)
+    }
+
+    #[inline]
+    fn i128(&mut self, v: i128) -> stream::Result {
+        self.i128(v)
+    }
+
+    #[inline]
+    fn u128(&mut self, v: u128) -> stream::Result {
+        self.u128(v)
+    }
+
+    #[inline]
+    fn f64(&mut self, v: f64) -> stream::Result {
+        self.f64(v)
+    }
+
+    #[inline]
+    fn bool(&mut self, v: bool) -> stream::Result {
+        self.bool(v)
+    }
+
+    #[inline]
+    fn char(&mut self, v: char) -> stream::Result {
+        self.char(v)
+    }
+
+    #[inline]
+    fn str(&mut self, v: &str) -> stream::Result {
+        self.str(v)
+    }
+
+    #[inline]
+    fn none(&mut self) -> stream::Result {
+        self.none()
+    }
+
+    #[inline]
+    fn map_begin(&mut self, len: Option<usize>) -> stream::Result {
+        self.map_begin(len)
+    }
+
+    #[inline]
+    fn map_key(&mut self) -> stream::Result {
+        self.map_key_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn map_value(&mut self) -> stream::Result {
+        self.map_value_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn map_end(&mut self) -> stream::Result {
+        self.map_end()
+    }
+
+    #[inline]
+    fn seq_begin(&mut self, len: Option<usize>) -> stream::Result {
+        self.seq_begin(len)
+    }
+
+    #[inline]
+    fn seq_elem(&mut self) -> stream::Result {
+        self.seq_elem_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn seq_end(&mut self) -> stream::Result {
+        self.seq_end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::stream::Stack;
+
+    #[test]
+    fn owned_stream_method_resolution() {
+        fn takes_owned_stream(mut stream: OwnedStream<impl Stream>) -> stream::Result {
+            stream.map_begin(None)?;
+            stream.map_key("key")?;
+            stream.map_value(42)?;
+            stream.map_end()
+        }
+
+        fn takes_stream(mut stream: impl Stream) -> stream::Result {
+            stream.map_begin(None)?;
+            stream.map_key()?;
+            stream.str("key")?;
+            stream.map_value()?;
+            stream.i64(42)?;
+            stream.map_end()
+        }
+
+        takes_owned_stream(OwnedStream::new(Stack::default())).expect("failed to use owned stream");
+        takes_stream(OwnedStream::new(Stack::default())).expect("failed to use stream");
+    }
+
+    #[test]
+    fn ref_mut_stream_method_resolution() {
+        fn takes_ref_mut_stream(mut stream: RefMutStream) -> stream::Result {
+            stream.map_begin(None)?;
+            stream.map_key("key")?;
+            stream.map_value(42)?;
+            stream.map_end()
+        }
+
+        fn takes_stream(mut stream: impl Stream) -> stream::Result {
+            stream.map_begin(None)?;
+            stream.map_key()?;
+            stream.str("key")?;
+            stream.map_value()?;
+            stream.i64(42)?;
+            stream.map_end()
+        }
+
+        takes_ref_mut_stream(OwnedStream::new(Stack::default()).borrow_mut())
+            .expect("failed to use ref mut stream");
+        takes_stream(OwnedStream::new(Stack::default()).borrow_mut())
+            .expect("failed to use stream");
     }
 }

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -14,9 +14,14 @@ is maintained, but any changes here should be
 reviewed carefully.
 */
 
-use crate::std::fmt;
-
-use super::Error;
+use crate::{
+    std::fmt,
+    stream::{
+        self,
+        Error,
+        Stream,
+    },
+};
 
 /**
 The expected position in the stream.
@@ -501,6 +506,93 @@ impl Stack {
         } else {
             Err(Error::msg("stack is not empty"))
         }
+    }
+}
+
+impl Stream for Stack {
+    #[inline]
+    fn fmt(&mut self, _: stream::Arguments) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn i64(&mut self, _: i64) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn u64(&mut self, _: u64) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn i128(&mut self, _: i128) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn u128(&mut self, _: u128) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn f64(&mut self, _: f64) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn bool(&mut self, _: bool) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn char(&mut self, _: char) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn str(&mut self, _: &str) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn none(&mut self) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
+    fn map_begin(&mut self, _: Option<usize>) -> stream::Result {
+        self.map_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn map_key(&mut self) -> stream::Result {
+        self.map_key().map(|_| ())
+    }
+
+    #[inline]
+    fn map_value(&mut self) -> stream::Result {
+        self.map_value().map(|_| ())
+    }
+
+    #[inline]
+    fn map_end(&mut self) -> stream::Result {
+        self.map_end().map(|_| ())
+    }
+
+    #[inline]
+    fn seq_begin(&mut self, _: Option<usize>) -> stream::Result {
+        self.seq_begin().map(|_| ())
+    }
+
+    #[inline]
+    fn seq_elem(&mut self) -> stream::Result {
+        self.seq_elem().map(|_| ())
+    }
+
+    #[inline]
+    fn seq_end(&mut self) -> stream::Result {
+        self.seq_end().map(|_| ())
     }
 }
 

--- a/tests/serde_no_std/lib.rs
+++ b/tests/serde_no_std/lib.rs
@@ -95,5 +95,3 @@ fn sval_to_serde_anonymous() {
     // The anonymous map isn't supported in no-std
     sval::test::tokens(sval::serde::to_value(ser));
 }
-
-


### PR DESCRIPTION
The `OwnedStream` and `RefMutStream` types are logically `Stream`s, and it would be surprising for a consumer to discover that they aren't, creating friction when attempting to accept anything through a `impl Stream` bound.

The `Stack` type can also implement the `Stream` trait, even though it's not an immediately useful implementation it's a nice smoke-test that usages of `Stream`s are actually valid.