### PR TITLE
Use old-style type annotations and run fmt

### DIFF
--- a/json/tests/src/lib.rs
+++ b/json/tests/src/lib.rs
@@ -9,18 +9,16 @@ use miniserde::Serialize as MiniSerialize;
 #[test]
 fn sval_json_writer_is_valid() {
     sval::test::stream_exhaustive(
-        || {
-            sval_json::Writer::new(Vec::new())
-        },
+        || sval_json::Writer::new(Vec::new()),
         |writer| match writer {
             // If the result is ok then the writer should be valid
             Ok(writer) => {
                 writer.end().unwrap();
-            },
+            }
             // If the result is not ok then the error should be unsupported
             // This will happen with non-string keys
             Err(e) => assert!(e.is_unsupported()),
-        }
+        },
     );
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,10 @@ impl Error {
     /** Declare some structure as unsupported. */
     #[inline]
     pub fn unsupported(operation: &'static str) -> Self {
-        Error(ErrorInner::Unsupported { msg: operation, default: false })
+        Error(ErrorInner::Unsupported {
+            msg: operation,
+            default: false,
+        })
     }
 
     /** Whether or not an error is because some operation was unsupported. */
@@ -39,7 +42,10 @@ impl Error {
 
     #[allow(dead_code)]
     pub(crate) fn default_unsupported(operation: &'static str) -> Self {
-        Error(ErrorInner::Unsupported { msg: operation, default: true })
+        Error(ErrorInner::Unsupported {
+            msg: operation,
+            default: true,
+        })
     }
 
     #[allow(dead_code)]
@@ -80,7 +86,9 @@ enum ErrorInner {
 impl fmt::Debug for ErrorInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ErrorInner::Unsupported { msg: op, .. } => write!(f, "unsupported stream operation: {}", op),
+            ErrorInner::Unsupported { msg: op, .. } => {
+                write!(f, "unsupported stream operation: {}", op)
+            }
             ErrorInner::Static(msg) => msg.fmt(f),
             #[cfg(not(feature = "alloc"))]
             ErrorInner::Custom(ref err) => err.fmt(f),
@@ -93,7 +101,9 @@ impl fmt::Debug for ErrorInner {
 impl fmt::Display for ErrorInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ErrorInner::Unsupported { msg: op, .. } => write!(f, "unsupported stream operation: {}", op),
+            ErrorInner::Unsupported { msg: op, .. } => {
+                write!(f, "unsupported stream operation: {}", op)
+            }
             ErrorInner::Static(msg) => msg.fmt(f),
             #[cfg(not(feature = "alloc"))]
             ErrorInner::Custom(ref err) => err.fmt(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,9 +222,9 @@ mod std {
     pub use crate::alloc_lib::{
         boxed,
         collections,
-        vec,
-        string,
         rc,
+        string,
+        vec,
     };
 
     pub use crate::core_lib::*;

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -31,7 +31,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl ser::StdError for Error { }
+impl ser::StdError for Error {}
 
 pub(super) fn err<E>(msg: &'static str) -> impl FnOnce(E) -> crate::Error
 where

--- a/src/serde/to_serialize.rs
+++ b/src/serde/to_serialize.rs
@@ -503,7 +503,10 @@ mod alloc_support {
                 None => {
                     match self.take_current() {
                         Current::Serializer(ser) => {
-                            let seq = ser.serialize_seq(len).map(Current::SerializeSeq).map_err(err("error serializing sequence"))?;
+                            let seq = ser
+                                .serialize_seq(len)
+                                .map(Current::SerializeSeq)
+                                .map_err(err("error serializing sequence"))?;
                             self.current = Some(seq);
                         }
                         current => {
@@ -558,7 +561,10 @@ mod alloc_support {
                 None => {
                     match self.take_current() {
                         Current::Serializer(ser) => {
-                            let map = ser.serialize_map(len).map(Current::SerializeMap).map_err(err("error serializing map"))?;
+                            let map = ser
+                                .serialize_map(len)
+                                .map(Current::SerializeMap)
+                                .map_err(err("error serializing map"))?;
                             self.current = Some(map);
                         }
                         current => {

--- a/src/test.rs
+++ b/src/test.rs
@@ -20,15 +20,15 @@ mod alloc_support {
             string::String,
             vec::Vec,
         },
+        stream::{
+            self,
+            OwnedStream,
+            Stream,
+        },
         value::{
             owned::Kind,
             OwnedValue,
             Value,
-        },
-        stream::{
-            self,
-            Stream,
-            OwnedStream,
         },
     };
 
@@ -166,7 +166,7 @@ mod alloc_support {
                         panic!("value `{:?}` is unsupported (a method on `Stream` hasn't been overriden)", tokens);
                     }
                 }
-                
+
                 check(r);
             };
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -112,7 +112,7 @@ mod alloc_support {
             Box::new('山'),
             Box::new("🍔∈🌏"),
             Box::new(Some(1)),
-            Box::new(Option::<u8>::None),
+            Box::new(Option::None::<u8>),
             Box::new(vec![1, 2, 3, 4]),
             Box::new({
                 let v: Vec<Box<dyn Value>> = vec![Box::new(1), Box::new('a')];

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -245,8 +245,8 @@ mod std_support {
     use crate::std::{
         collections::HashMap,
         hash::{
-            Hash,
             BuildHasher,
+            Hash,
         },
         sync::Arc,
     };

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -520,7 +520,9 @@ impl Primitive {
     }
 
     fn collect(v: impl Value) -> Option<Token> {
-        crate::stream(Primitive::new(), v).ok().and_then(|buf| buf.token)
+        crate::stream(Primitive::new(), v)
+            .ok()
+            .and_then(|buf| buf.token)
     }
 
     fn set(&mut self, kind: Kind, depth: stack::Depth) {

--- a/tests/serde_no_alloc/lib.rs
+++ b/tests/serde_no_alloc/lib.rs
@@ -17,7 +17,7 @@ sval_if_alloc! {
                 Value,
             },
         };
-        
+
         #[derive(Value)]
         struct Struct<'a> {
             a: i32,
@@ -25,41 +25,41 @@ sval_if_alloc! {
             #[sval(rename = "renamed")]
             c: Nested<'a>,
         }
-        
+
         #[derive(Value)]
         struct Nested<'a> {
             a: i32,
             b: &'a str,
         }
-        
+
         struct Anonymous;
-        
+
         impl Value for Anonymous {
             fn stream(&self, stream: &mut value::Stream) -> value::Result {
                 stream.map_begin(None)?;
-        
+
                 stream.map_key_begin()?.i64(1)?;
-        
+
                 stream.map_value_begin()?.map_begin(None)?;
-        
+
                 stream.map_key(2)?;
-        
+
                 stream.map_value_begin()?.seq_begin(None)?;
-        
+
                 stream.seq_elem_begin()?.i64(3)?;
-        
+
                 stream.seq_end()?;
-        
+
                 stream.map_end()?;
-        
+
                 stream.map_key(11)?;
-        
+
                 stream.map_value(111)?;
-        
+
                 stream.map_end()
             }
         }
-        
+
         #[test]
         fn sval_derive() {
             let ser = sval::serde::to_serialize(Struct {
@@ -67,7 +67,7 @@ sval_if_alloc! {
                 b: 2,
                 c: Nested { a: 3, b: "Hello!" },
             });
-        
+
             let v = sval::test::tokens(sval::serde::to_value(ser));
             assert_eq!(
                 vec![
@@ -88,14 +88,14 @@ sval_if_alloc! {
                 v
             );
         }
-        
+
         #[test]
         #[should_panic]
         fn sval_to_serde_anonymous() {
             let ser = sval::serde::to_serialize(Anonymous);
-        
+
             // The anonymous map isn't supported in no-std
             sval::test::tokens(sval::serde::to_value(ser));
-        }        
+        }
     }
 }


### PR DESCRIPTION
This PR is _mostly_ just running `cargo fmt`, but it also uses `Option::None::<T>` instead of `Option::<T>::None`, since the latter is a pretty new feature, and it looks like a typo to old compilers.