### PR TITLE
Respect fmt flags when forwarding Debug

### DIFF
--- a/src/fmt/to_debug.rs
+++ b/src/fmt/to_debug.rs
@@ -73,11 +73,9 @@ impl<'a, 'b: 'a> Stream<'a, 'b> {
     fn is_pretty(&self) -> bool {
         self.fmt.alternate()
     }
-}
 
-impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     #[inline]
-    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
+    fn fmt(&mut self, v: impl fmt::Debug) -> stream::Result {
         let pos = self.stack.primitive()?;
 
         let next_delim = self.next_delim(pos);
@@ -89,45 +87,52 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
 
         Ok(())
     }
+}
+
+impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
+    #[inline]
+    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
+        self.fmt(v)
+    }
 
     #[inline]
     fn i64(&mut self, v: i64) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]
     fn u64(&mut self, v: u64) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]
     fn i128(&mut self, v: i128) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]
     fn u128(&mut self, v: u128) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]
     fn f64(&mut self, v: f64) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]
     fn bool(&mut self, v: bool) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]
     fn char(&mut self, v: char) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]
     fn str(&mut self, v: &str) -> stream::Result {
-        self.fmt(format_args!("{:?}", v))
+        self.fmt(v)
     }
 
     #[inline]

--- a/tests/fmt/lib.rs
+++ b/tests/fmt/lib.rs
@@ -221,3 +221,19 @@ fn sval_alternate_fmt_is_consistent() {
     check(OuterSeq);
     check(WeirdMapKeys);
 }
+
+#[test]
+fn sval_fmt_retains_flags() {
+    fn check(value: (impl Value + Debug)) {
+        let sval = format!("{:04?}", sval::fmt::to_debug(&value));
+        let std = format!("{:04?}", value);
+
+        assert_eq!(std, sval);
+    }
+
+    check(42);
+    check("a string");
+    check(OuterMap);
+    check(OuterSeq);
+    check(WeirdMapKeys);
+}


### PR DESCRIPTION
Fixes #84 

Threads the value directly to the formatter instead of wrapping it up in `Arguments`, so that flags are preserved.