### PR TITLE
Deprecate root level traits and nested Errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ fn with_value(value: impl sval::Value) {
 */
 
 #![doc(html_root_url = "https://docs.rs/sval/0.5.2")]
+#![allow(deprecated)]
 #![no_std]
 
 #[doc(hidden)]
@@ -251,11 +252,13 @@ pub mod serde;
 pub mod stream;
 pub mod value;
 
-pub use self::{
-    error::Error,
-    stream::Stream,
-    value::Value,
-};
+pub use self::error::Error;
+
+#[deprecated(since = "0.5.3", note = "use `sval::stream::Stream`")]
+pub use self::stream::Stream;
+
+#[deprecated(since = "0.5.3", note = "use `sval::value::Value`")]
+pub use self::value::Value;
 
 /**
 Stream the structure of a [`Value`] using the given [`Stream`].

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -208,6 +208,7 @@ pub mod stack;
 use crate::std::fmt;
 
 #[doc(inline)]
+#[deprecated(since = "0.5.3", note = "use the provided `Result` alias or `sval::Error`")]
 pub use crate::Error;
 
 pub use self::{

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -132,6 +132,7 @@ pub use crate::stream::RefMutStream as Stream;
 pub use self::owned::OwnedValue;
 
 #[doc(inline)]
+#[deprecated(since = "0.5.3", note = "use the provided `Result` alias or `sval::Error`")]
 pub use crate::Error;
 
 /**


### PR DESCRIPTION
In preparation for #89 

This PR deprecates a few re-exports that are going away soon. There are other changes that are likely to cause breakage and can't be expressed by deprecations, but since we're still in low-use mode I'll go through and update consumers that pop up.