### PR TITLE
Prepare for 0.6.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "sval"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval"
@@ -68,7 +68,7 @@ default-features = false
 package = "serde"
 
 [dependencies.sval_derive]
-version = "0.5.2"
+version = "0.6.0"
 path = "./derive"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add `sval` to your crate dependencies:
 
 ```toml
 [dependencies.sval]
-version = "0.5.2"
+version = "0.6.0"
 ```
 
 ## To support my data-structures
@@ -88,7 +88,7 @@ The `sval_json` crate can format any `sval::Value` as JSON:
 
 ```toml
 [dependencies.sval_json]
-version = "0.5.2"
+version = "0.6.0"
 features = ["std"]
 ```
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_derive"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,7 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_derive/0.5.2")]
+#![doc(html_root_url = "https://docs.rs/sval_derive/0.6.0")]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_json"
@@ -22,7 +22,7 @@ travis-ci = { repository = "KodrAus/sval" }
 std = ["sval/std"]
 
 [dependencies.sval]
-version = "0.5.2"
+version = "0.6.0"
 path = "../"
 
 [dependencies.ryu]

--- a/json/README.md
+++ b/json/README.md
@@ -25,7 +25,7 @@ Add `sval_json` to your crate dependencies:
 
 ```toml
 [dependencies.sval_json]
-version = "0.5.2"
+version = "0.6.0"
 ```
 
 ## To write JSON to a `fmt::Write`

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -10,7 +10,7 @@ Add `sval_json` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval_json]
-version = "0.5.2"
+version = "0.6.0"
 ```
 
 # Writing JSON to `fmt::Write`
@@ -79,7 +79,7 @@ let json = sval_json::to_writer(MyWrite, 42)?;
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_json/0.5.2")]
+#![doc(html_root_url = "https://docs.rs/sval_json/0.6.0")]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval]
-version = "0.5.2"
+version = "0.6.0"
 ```
 
 # Supported formats
@@ -170,7 +170,7 @@ fn with_value(value: impl Value) {
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval/0.5.2")]
+#![doc(html_root_url = "https://docs.rs/sval/0.6.0")]
 #![no_std]
 
 #[doc(hidden)]


### PR DESCRIPTION
Includes #89 

Which refactors our public API to be closer to something that could be released as a `1.0`.