### PR TITLE
Replace impl Trait returns with concrete types

### DIFF
--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -37,6 +37,8 @@ use crate::{
 
 mod to_debug;
 
+pub use self::to_debug::ToDebug;
+
 /**
 Convert a [`Value`] into a [`Debug`].
 
@@ -45,8 +47,11 @@ a `Debug` implementation that might exist on the type.
 
 This method doesn't need to allocate or perform any buffering.
 */
-pub fn to_debug(value: impl Value) -> impl Debug {
-    self::to_debug::ToDebug(value)
+pub fn to_debug<V>(value: V) -> ToDebug<V>
+where
+    V: Value,
+{
+    ToDebug(value)
 }
 
 /**

--- a/src/fmt/to_debug.rs
+++ b/src/fmt/to_debug.rs
@@ -18,7 +18,11 @@ use crate::{
     value,
 };
 
-pub(super) struct ToDebug<V>(pub(super) V);
+/**
+The result of calling [`sval::fmt::to_debug`].
+*/
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ToDebug<V>(pub(super) V);
 
 impl<V> Debug for ToDebug<V>
 where

--- a/src/fmt/to_debug.rs
+++ b/src/fmt/to_debug.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /**
-The result of calling [`sval::fmt::to_debug`].
+The result of calling [`sval::fmt::to_debug`](fn.to_debug.html).
 */
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ToDebug<V>(pub(super) V);

--- a/src/serde/v1/mod.rs
+++ b/src/serde/v1/mod.rs
@@ -69,6 +69,11 @@ use serde1_lib::ser::{
     Serializer,
 };
 
+pub use self::{
+    to_serialize::ToSerialize,
+    to_value::ToValue,
+};
+
 /**
 Convert a [`Value`] into a [`Serialize`].
 
@@ -76,8 +81,11 @@ If the `Value` uses nested maps or sequences where the keys, values
 or elements aren't known upfront then this method will need to allocate
 for them.
 */
-pub fn to_serialize(value: impl Value) -> impl Serialize {
-    to_serialize::ToSerialize(value)
+pub fn to_serialize<V>(value: V) -> ToSerialize<V>
+where
+    V: Value,
+{
+    ToSerialize(value)
 }
 
 /**
@@ -93,8 +101,11 @@ where
 /**
 Convert a [`Serialize`] into a [`Value`].
 */
-pub fn to_value(value: impl Serialize) -> impl Value {
-    to_value::ToValue(value)
+pub fn to_value<S>(value: S) -> ToValue<S>
+where
+    S: Serialize,
+{
+    ToValue(value)
 }
 
 /**

--- a/src/serde/v1/mod.rs
+++ b/src/serde/v1/mod.rs
@@ -28,8 +28,8 @@ let my_serialize = sval::serde::v1::to_serialize(my_value);
 When using `serde` without `alloc`, there are some limitations on what kinds of `sval::Value`s you
 can convert into `serde::Serialize`s:
 
-- Any type that uses [`value::Stream::map_key_begin`], [`value::Stream::map_value_begin`],
-or [`value::Stream::seq_elem_begin`] would require buffering, so will return an error instead
+- Any type that uses `map_key_begin`, `map_value_begin`,
+or `seq_elem_begin` would require buffering, so will return an error instead
 in no-std environments.
 
 # From `serde` to `sval`

--- a/src/serde/v1/to_serialize.rs
+++ b/src/serde/v1/to_serialize.rs
@@ -18,7 +18,11 @@ use serde1_lib::ser::{
     Serializer,
 };
 
-pub(super) struct ToSerialize<V>(pub(super) V);
+/**
+The result of calling [`sval::serde::v1::to_serialize`].
+*/
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ToSerialize<V>(pub(super) V);
 
 impl<V> Serialize for ToSerialize<V>
 where

--- a/src/serde/v1/to_serialize.rs
+++ b/src/serde/v1/to_serialize.rs
@@ -19,7 +19,7 @@ use serde1_lib::ser::{
 };
 
 /**
-The result of calling [`sval::serde::v1::to_serialize`].
+The result of calling [`sval::serde::v1::to_serialize`](fn.to_serialize.html).
 */
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ToSerialize<V>(pub(super) V);

--- a/src/serde/v1/to_value.rs
+++ b/src/serde/v1/to_value.rs
@@ -21,7 +21,11 @@ use serde1_lib::ser::{
     SerializeTupleVariant,
 };
 
-pub(super) struct ToValue<T>(pub(super) T);
+/**
+The result of calling [`sval::serde::v1::to_value`].
+*/
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ToValue<T>(pub(super) T);
 
 impl<T> value::Value for ToValue<T>
 where

--- a/src/serde/v1/to_value.rs
+++ b/src/serde/v1/to_value.rs
@@ -22,7 +22,7 @@ use serde1_lib::ser::{
 };
 
 /**
-The result of calling [`sval::serde::v1::to_value`].
+The result of calling [`sval::serde::v1::to_value`](fn.to_value.html).
 */
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ToValue<T>(pub(super) T);


### PR DESCRIPTION
So that we can name and derive other traits on these wrapper types returned by conversion methods.