### PR TITLE
Support streaming errors

### DIFF
--- a/json/src/fmt.rs
+++ b/json/src/fmt.rs
@@ -139,6 +139,11 @@ where
     }
 
     #[inline]
+    fn error(&mut self, v: stream::Source) -> stream::Result {
+        self.fmt(stream::Arguments::display(&v))
+    }
+
+    #[inline]
     fn i64(&mut self, v: i64) -> stream::Result {
         self.i128(v as i128)
     }

--- a/json/src/std_support.rs
+++ b/json/src/std_support.rs
@@ -18,7 +18,6 @@ use crate::{
     },
     End,
 };
-use sval::stream::Arguments;
 
 impl<T> Error for End<T> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
@@ -129,8 +128,14 @@ impl<W> Stream for Writer<W>
 where
     W: Write,
 {
-    fn fmt(&mut self, v: Arguments) -> stream::Result {
+    #[inline]
+    fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
         self.0.fmt(v)
+    }
+
+    #[inline]
+    fn error(&mut self, v: stream::Source) -> stream::Result {
+        self.0.error(v)
     }
 
     #[inline]

--- a/src/collect/mod.rs
+++ b/src/collect/mod.rs
@@ -9,6 +9,7 @@ allocating for nested datastructures that are already known.
 use crate::stream::{
     Arguments,
     Stream,
+    Source,
 };
 
 mod owned;
@@ -97,6 +98,11 @@ where
     #[inline]
     fn fmt(&mut self, v: Arguments) -> Result {
         self.0.fmt(v)
+    }
+
+    #[inline]
+    fn error(&mut self, v: Source) -> Result {
+        self.0.error(v)
     }
 
     #[inline]

--- a/src/collect/owned.rs
+++ b/src/collect/owned.rs
@@ -9,12 +9,15 @@ use crate::{
         Debug,
         Display,
     },
-    stream::{Arguments, Source},
+    stream::Arguments,
     value,
 };
 
 #[cfg(feature = "std")]
-use crate::std::error;
+use crate::{
+    std::error,
+    stream::Source,
+};
 
 pub(crate) struct OwnedCollect<TStream> {
     stream: TStream,

--- a/src/collect/owned.rs
+++ b/src/collect/owned.rs
@@ -9,9 +9,12 @@ use crate::{
         Debug,
         Display,
     },
-    stream::Arguments,
+    stream::{Arguments, Source},
     value,
 };
+
+#[cfg(feature = "std")]
+use crate::std::error;
 
 pub(crate) struct OwnedCollect<TStream> {
     stream: TStream,
@@ -39,6 +42,12 @@ where
     #[inline]
     pub fn any(&mut self, v: impl value::Value) -> collect::Result {
         v.stream(&mut value::Stream::new(self.borrow_mut()))
+    }
+
+    #[inline]
+    #[cfg(feature = "std")]
+    pub fn error(&mut self, v: impl error::Error) -> collect::Result {
+        self.stream.error(Source::from(&v as &dyn error::Error))
     }
 
     #[inline]
@@ -159,6 +168,12 @@ impl<'a> RefMutCollect<'a> {
     #[inline]
     pub fn any(&mut self, v: impl value::Value) -> collect::Result {
         self.0.any(v)
+    }
+
+    #[inline]
+    #[cfg(feature = "std")]
+    pub fn error(&mut self, v: impl error::Error) -> collect::Result {
+        self.0.error(v)
     }
 
     #[inline]

--- a/src/fmt/to_debug.rs
+++ b/src/fmt/to_debug.rs
@@ -100,6 +100,11 @@ impl<'a, 'b: 'a> stream::Stream for Stream<'a, 'b> {
     }
 
     #[inline]
+    fn error(&mut self, v: stream::Source) -> stream::Result {
+        self.fmt(v)
+    }
+
+    #[inline]
     fn i64(&mut self, v: i64) -> stream::Result {
         self.fmt(v)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,42 @@ macro_rules! sval_if_alloc {
 }
 
 #[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "std")]
+macro_rules! sval_if_std {
+    (
+        if #[cfg(feature = "std")]
+        {
+            $($with:tt)*
+        }
+        else
+        {
+            $($without:tt)*
+        }
+    ) => {
+        $($with)*
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "std"))]
+macro_rules! sval_if_std {
+    (
+        if #[cfg(feature = "std")]
+        {
+            $($with:tt)*
+        }
+        else
+        {
+            $($without:tt)*
+        }
+    ) => {
+        $($without)*
+    };
+}
+
+#[doc(hidden)]
 #[cfg(feature = "derive")]
 pub mod derive;
 

--- a/src/serde/v1/to_serialize.rs
+++ b/src/serde/v1/to_serialize.rs
@@ -253,6 +253,23 @@ impl<'a> stream::Arguments<'a> {
     }
 }
 
+impl<'a> stream::Source<'a> {
+    fn to_serialize<'b>(&'b self) -> impl Serialize + 'b {
+        struct SerializeSource<'a, 'b>(&'b stream::Source<'a>);
+
+        impl<'a, 'b> Serialize for SerializeSource<'a, 'b> {
+            fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                s.collect_str(&self.0)
+            }
+        }
+
+        SerializeSource(self)
+    }
+}
+
 enum Pos {
     Key,
     Value,
@@ -289,6 +306,11 @@ mod no_alloc_support {
     {
         #[inline]
         fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
+            self.serialize_any(v.to_serialize())
+        }
+
+        #[inline]
+        fn error(&mut self, v: stream::Error) -> stream::Result {
             self.serialize_any(v.to_serialize())
         }
 
@@ -715,6 +737,14 @@ mod alloc_support {
         }
 
         #[inline]
+        fn error(&mut self, v: stream::Source) -> stream::Result {
+            match self.buffer() {
+                None => self.serialize_any(v.to_serialize()),
+                Some(buffered) => buffered.error(v),
+            }
+        }
+
+        #[inline]
         fn fmt(&mut self, v: stream::Arguments) -> stream::Result {
             match self.buffer() {
                 None => self.serialize_any(v.to_serialize()),
@@ -830,6 +860,11 @@ mod alloc_support {
                         reader.expect_empty().map_err(S::Error::custom)?;
 
                         v.serialize(serializer)
+                    }
+                    Kind::Error(ref v) => {
+                        reader.expect_empty().map_err(S::Error::custom)?;
+
+                        stream::Source::from(&**v).to_serialize().serialize(serializer)
                     }
                     Kind::None => {
                         reader.expect_empty().map_err(S::Error::custom)?;

--- a/src/serde/v1/to_serialize.rs
+++ b/src/serde/v1/to_serialize.rs
@@ -310,7 +310,7 @@ mod no_alloc_support {
         }
 
         #[inline]
-        fn error(&mut self, v: stream::Error) -> stream::Result {
+        fn error(&mut self, v: stream::Source) -> stream::Result {
             self.serialize_any(v.to_serialize())
         }
 

--- a/src/stream/error.rs
+++ b/src/stream/error.rs
@@ -7,7 +7,7 @@ use crate::std::{
 /**
 A streamable error.
 
-This type shouldn't be confused with [`sval::Error`], which is
+This type shouldn't be confused with [`sval::Error`](../../struct.Error.html), which is
 used to communicate errors back to callers.
 The purpose of the `Source` type is to let streams serialize
 error types, that may have backtraces and other metadata.

--- a/src/stream/error.rs
+++ b/src/stream/error.rs
@@ -164,4 +164,21 @@ mod std_support {
             }
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        use crate::std::io;
+
+        #[test]
+        fn error_downcast() {
+            let err = io::Error::from(io::ErrorKind::Other);
+
+            let source = Source::new(&err);
+
+            // Downcasting isn't supported by `Source`
+            assert!(source.as_ref().downcast_ref::<io::Error>().is_none());
+        }
+    }
 }

--- a/src/stream/error.rs
+++ b/src/stream/error.rs
@@ -1,0 +1,167 @@
+
+use crate::std::{
+    fmt,
+};
+
+
+/**
+A streamable error.
+
+This type shouldn't be confused with [`sval::Error`], which is
+used to communicate errors back to callers.
+The purpose of the `Source` type is to let streams serialize
+error types, that may have backtraces and other metadata.
+
+`Source`s can only be created when the `std` feature is available,
+but streams can still work with them by formatting them or passing
+them along even in no-std environments where the `Error` trait isn't available.
+*/
+pub struct Source<'a> {
+    #[cfg(feature = "std")]
+    inner: self::std_support::SourceError<'a>,
+    #[cfg(not(feature = "std"))]
+    _marker: crate::std::marker::PhantomData<&'a dyn crate::std::any::Any>,
+}
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+impl<'a> Source<'a> {
+    pub(crate) fn empty() -> Self {
+        Source {
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Source<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(feature = "std")]
+        {
+            fmt::Debug::fmt(&self.inner, f)
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            f.debug_struct("Source").finish()
+        }
+    }
+}
+
+impl<'a> fmt::Display for Source<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(feature = "std")]
+        {
+            fmt::Display::fmt(&self.inner, f)
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            f.debug_struct("Source").finish()
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_support {
+    use crate::std::{
+        fmt,
+        error::Error,
+        marker::PhantomData,
+        mem,
+    };
+
+    use super::Source;
+
+    pub(super) struct SourceError<'a> {
+        extended: ExtendedLifetimeError,
+        _marker: PhantomData<&'a dyn Error>,
+    }
+
+    impl<'a> fmt::Debug for SourceError<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Debug::fmt(&self.extended, f)
+        }
+    }
+
+    impl<'a> fmt::Display for SourceError<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(&self.extended, f)
+        }
+    }
+
+    /**
+    A wrapper over an error type with an artificially extended lifetime.
+
+    Borrows of this value are returned by `SourceError` but it's important
+    that callers can't get at the inner `&'static dyn Error` directly. They
+    also can't downcast the value to a `ExtendedLifetimeError` or the inner
+    value even if it does support downcasting, but they can iterate its causes
+    and grab a backtrace.
+    */
+    struct ExtendedLifetimeError(&'static dyn Error);
+
+    impl fmt::Debug for ExtendedLifetimeError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Debug::fmt(self.0, f)
+        }
+    }
+
+    impl fmt::Display for ExtendedLifetimeError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(self.0, f)
+        }
+    }
+
+    impl Error for ExtendedLifetimeError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.0.source()
+        }
+
+        // NOTE: Once backtraces are stable, add them here too
+    }
+
+    impl<'a> Error for &'a ExtendedLifetimeError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.0.source()
+        }
+
+        // NOTE: Once backtraces are stable, add them here too
+    }
+
+    impl<'a> Source<'a> {
+        /**
+        Capture an error source from a standard error.
+
+        This method is only available when the `std` feature is enabled.
+        */
+        pub fn new(err: &'a impl Error) -> Self {
+            Source::from(err as &'a dyn Error)
+        }
+
+        /**
+        Get the inner error.
+        */
+        pub fn get<'b>(&'b self) -> impl Error + 'b {
+            &self.inner.extended
+        }
+    }
+
+    impl<'a> AsRef<dyn Error + 'static> for Source<'a> {
+        fn as_ref(&self) -> &(dyn Error + 'static) {
+            &self.inner.extended
+        }
+    }
+
+    impl<'a> From<&'a dyn Error> for Source<'a> {
+        fn from(err: &'a dyn Error) -> Self {
+            Source {
+                inner: SourceError {
+                    // SAFETY: We're careful not to expose the actual value with the fake lifetime
+                    // Calling code can only interact with it through an arbitrarily short borrow
+                    // that's bound to `'a` from `self`, which is the real McCoy lifetime of the error
+                    extended: ExtendedLifetimeError(unsafe { mem::transmute::<&'a dyn Error, &'static dyn Error>(err) }),
+                    _marker: PhantomData,
+                },
+            }
+        }
+    }
+}

--- a/src/stream/fmt.rs
+++ b/src/stream/fmt.rs
@@ -1,0 +1,81 @@
+use crate::std::{
+    fmt,
+};
+
+
+/**
+A formattable value.
+*/
+pub struct Arguments<'a>(ArgumentsInner<'a>);
+
+enum ArgumentsInner<'a> {
+    Debug(&'a dyn fmt::Debug),
+    Display(&'a dyn fmt::Display),
+    Args(fmt::Arguments<'a>),
+}
+
+impl<'a> Arguments<'a> {
+    /**
+    Capture standard format arguments.
+
+    Prefer the [`debug`] and [`display`] methods to create 
+    `Arguments` over passing them through `format_args`,
+    because `format_args` will clobber any flags a stream
+    might want to format these arguments with.
+    */
+    pub fn new(v: fmt::Arguments<'a>) -> Self {
+        Arguments(ArgumentsInner::Args(v))
+    }
+
+    /**
+    Capture arguments from a debuggable value.
+    */
+    pub fn debug(v: &'a impl fmt::Debug) -> Self {
+        Arguments(ArgumentsInner::Debug(v))
+    }
+
+    /**
+    Capture arguments from a displayable value.
+    */
+    pub fn display(v: &'a impl fmt::Display) -> Self {
+        Arguments(ArgumentsInner::Display(v))
+    }
+}
+
+impl<'a> From<fmt::Arguments<'a>> for Arguments<'a> {
+    fn from(v: fmt::Arguments<'a>) -> Self {
+        Arguments(ArgumentsInner::Args(v))
+    }
+}
+
+impl<'a> From<&'a dyn fmt::Debug> for Arguments<'a> {
+    fn from(v: &'a dyn fmt::Debug) -> Self {
+        Arguments(ArgumentsInner::Debug(v))
+    }
+}
+
+impl<'a> From<&'a dyn fmt::Display> for Arguments<'a> {
+    fn from(v: &'a dyn fmt::Display) -> Self {
+        Arguments(ArgumentsInner::Display(v))
+    }
+}
+
+impl<'a> fmt::Debug for Arguments<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0 {
+            ArgumentsInner::Debug(v) => v.fmt(f),
+            ArgumentsInner::Display(v) => v.fmt(f),
+            ArgumentsInner::Args(v) => v.fmt(f),
+        }
+    }
+}
+
+impl<'a> fmt::Display for Arguments<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0 {
+            ArgumentsInner::Debug(v) => v.fmt(f),
+            ArgumentsInner::Display(v) => v.fmt(f),
+            ArgumentsInner::Args(v) => v.fmt(f),
+        }
+    }
+}

--- a/src/stream/fmt.rs
+++ b/src/stream/fmt.rs
@@ -18,7 +18,7 @@ impl<'a> Arguments<'a> {
     /**
     Capture standard format arguments.
 
-    Prefer the [`debug`] and [`display`] methods to create 
+    Prefer the [`debug`](#method.debug) and [`display`](#method.display) methods to create 
     `Arguments` over passing them through `format_args`,
     because `format_args` will clobber any flags a stream
     might want to format these arguments with.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1021,16 +1021,15 @@ mod std_support {
         }
 
         /**
-        Get the value of the underlying error.
+        Get the inner error.
         */
-        pub fn get(&self) -> &(dyn Error + 'static) {
+        pub fn get<'b>(&'b self) -> impl Error + 'b {
             &self.inner.extended
         }
+    }
 
-        /**
-        Unwrap the inner error.
-        */
-        pub(crate) fn to_error<'b>(&'b self) -> impl Error + 'b {
+    impl<'a> AsRef<dyn Error + 'static> for Source<'a> {
+        fn as_ref(&self) -> &(dyn Error + 'static) {
             &self.inner.extended
         }
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -202,12 +202,10 @@ structures aren't supported. See the [`stream::Stack`] type for more details.
 [`stream::Stack`]: stack/struct.Stack.html
 */
 
+mod fmt;
+mod error;
 pub(crate) mod owned;
 pub mod stack;
-
-use crate::std::{
-    fmt,
-};
 
 pub use self::{
     owned::{
@@ -215,140 +213,10 @@ pub use self::{
         RefMutStream,
     },
     stack::Stack,
+    fmt::Arguments,
+    error::Source,
 };
 
-/**
-A formattable value.
-*/
-pub struct Arguments<'a>(ArgumentsInner<'a>);
-
-enum ArgumentsInner<'a> {
-    Debug(&'a dyn fmt::Debug),
-    Display(&'a dyn fmt::Display),
-    Args(fmt::Arguments<'a>),
-}
-
-impl<'a> Arguments<'a> {
-    /**
-    Capture standard format arguments.
-
-    Prefer the [`debug`] and [`display`] methods to create 
-    `Arguments` over passing them through `format_args`,
-    because `format_args` will clobber any flags a stream
-    might want to format these arguments with.
-    */
-    pub fn new(v: fmt::Arguments<'a>) -> Self {
-        Arguments(ArgumentsInner::Args(v))
-    }
-
-    /**
-    Capture arguments from a debuggable value.
-    */
-    pub fn debug(v: &'a impl fmt::Debug) -> Self {
-        Arguments(ArgumentsInner::Debug(v))
-    }
-
-    /**
-    Capture arguments from a displayable value.
-    */
-    pub fn display(v: &'a impl fmt::Display) -> Self {
-        Arguments(ArgumentsInner::Display(v))
-    }
-}
-
-impl<'a> From<fmt::Arguments<'a>> for Arguments<'a> {
-    fn from(v: fmt::Arguments<'a>) -> Self {
-        Arguments(ArgumentsInner::Args(v))
-    }
-}
-
-impl<'a> From<&'a dyn fmt::Debug> for Arguments<'a> {
-    fn from(v: &'a dyn fmt::Debug) -> Self {
-        Arguments(ArgumentsInner::Debug(v))
-    }
-}
-
-impl<'a> From<&'a dyn fmt::Display> for Arguments<'a> {
-    fn from(v: &'a dyn fmt::Display) -> Self {
-        Arguments(ArgumentsInner::Display(v))
-    }
-}
-
-impl<'a> fmt::Debug for Arguments<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            ArgumentsInner::Debug(v) => v.fmt(f),
-            ArgumentsInner::Display(v) => v.fmt(f),
-            ArgumentsInner::Args(v) => v.fmt(f),
-        }
-    }
-}
-
-impl<'a> fmt::Display for Arguments<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            ArgumentsInner::Debug(v) => v.fmt(f),
-            ArgumentsInner::Display(v) => v.fmt(f),
-            ArgumentsInner::Args(v) => v.fmt(f),
-        }
-    }
-}
-
-/**
-A streamable error.
-
-This type shouldn't be confused with [`sval::Error`], which is
-used to communicate errors back to callers.
-The purpose of the `Source` type is to let streams serialize
-error types, that may have backtraces and other metadata.
-
-`Source`s can only be created when the `std` feature is available,
-but streams can still work with them by formatting them or passing
-them along even in no-std environments where the `Error` trait isn't available.
-*/
-pub struct Source<'a> {
-    #[cfg(feature = "std")]
-    inner: self::std_support::SourceError<'a>,
-    #[cfg(not(feature = "std"))]
-    _marker: crate::std::marker::PhantomData<&'a dyn crate::std::any::Any>,
-}
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-impl<'a> Source<'a> {
-    pub(crate) fn empty() -> Self {
-        Source {
-            _marker: Default::default(),
-        }
-    }
-}
-
-impl<'a> fmt::Debug for Source<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        #[cfg(feature = "std")]
-        {
-            fmt::Debug::fmt(&self.inner, f)
-        }
-
-        #[cfg(not(feature = "std"))]
-        {
-            f.debug_struct("Source").finish()
-        }
-    }
-}
-
-impl<'a> fmt::Display for Source<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        #[cfg(feature = "std")]
-        {
-            fmt::Display::fmt(&self.inner, f)
-        }
-
-        #[cfg(not(feature = "std"))]
-        {
-            f.debug_struct("Source").finish()
-        }
-    }
-}
 
 /**
 A receiver for the structure of a value.
@@ -942,112 +810,6 @@ where
 The type returned by streaming methods.
 */
 pub type Result = crate::std::result::Result<(), crate::Error>;
-
-#[cfg(feature = "std")]
-mod std_support {
-    use crate::std::{
-        fmt,
-        error::Error,
-        marker::PhantomData,
-        mem,
-    };
-
-    use super::Source;
-
-    pub(super) struct SourceError<'a> {
-        extended: ExtendedLifetimeError,
-        _marker: PhantomData<&'a dyn Error>,
-    }
-
-    impl<'a> fmt::Debug for SourceError<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            fmt::Debug::fmt(&self.extended, f)
-        }
-    }
-
-    impl<'a> fmt::Display for SourceError<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            fmt::Display::fmt(&self.extended, f)
-        }
-    }
-
-    /**
-    A wrapper over an error type with an artificially extended lifetime.
-
-    Borrows of this value are returned by `SourceError` but it's important
-    that callers can't get at the inner `&'static dyn Error` directly. They
-    also can't downcast the value to a `ExtendedLifetimeError` or the inner
-    value even if it does support downcasting, but they can iterate its causes
-    and grab a backtrace.
-    */
-    struct ExtendedLifetimeError(&'static dyn Error);
-
-    impl fmt::Debug for ExtendedLifetimeError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            fmt::Debug::fmt(self.0, f)
-        }
-    }
-
-    impl fmt::Display for ExtendedLifetimeError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            fmt::Display::fmt(self.0, f)
-        }
-    }
-
-    impl Error for ExtendedLifetimeError {
-        fn source(&self) -> Option<&(dyn Error + 'static)> {
-            self.0.source()
-        }
-
-        // NOTE: Once backtraces are stable, add them here too
-    }
-
-    impl<'a> Error for &'a ExtendedLifetimeError {
-        fn source(&self) -> Option<&(dyn Error + 'static)> {
-            self.0.source()
-        }
-
-        // NOTE: Once backtraces are stable, add them here too
-    }
-
-    impl<'a> Source<'a> {
-        /**
-        Capture an error source from a standard error.
-
-        This method is only available when the `std` feature is enabled.
-        */
-        pub fn new(err: &'a impl Error) -> Self {
-            Source::from(err as &'a dyn Error)
-        }
-
-        /**
-        Get the inner error.
-        */
-        pub fn get<'b>(&'b self) -> impl Error + 'b {
-            &self.inner.extended
-        }
-    }
-
-    impl<'a> AsRef<dyn Error + 'static> for Source<'a> {
-        fn as_ref(&self) -> &(dyn Error + 'static) {
-            &self.inner.extended
-        }
-    }
-
-    impl<'a> From<&'a dyn Error> for Source<'a> {
-        fn from(err: &'a dyn Error) -> Self {
-            Source {
-                inner: SourceError {
-                    // SAFETY: We're careful not to expose the actual value with the fake lifetime
-                    // Calling code can only interact with it through an arbitrarily short borrow
-                    // that's bound to `'a` from `self`, which is the real McCoy lifetime of the error
-                    extended: ExtendedLifetimeError(unsafe { mem::transmute::<&'a dyn Error, &'static dyn Error>(err) }),
-                    _marker: PhantomData,
-                },
-            }
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/stream/owned.rs
+++ b/src/stream/owned.rs
@@ -15,6 +15,9 @@ use crate::{
     value::Value,
 };
 
+#[cfg(feature = "std")]
+use crate::std::error;
+
 /**
 An owned stream wrapper.
 
@@ -83,6 +86,17 @@ where
     #[inline]
     pub fn display(&mut self, v: impl Display) -> stream::Result {
         self.0.display(&v)
+    }
+
+    /**
+    Stream an error.
+
+    This method is only available when the `std` feature is enabled.
+    */
+    #[inline]
+    #[cfg(feature = "std")]
+    pub fn error(&mut self, v: impl error::Error) -> stream::Result {
+        self.0.error(v)
     }
 
     /**
@@ -259,6 +273,11 @@ where
     }
 
     #[inline]
+    fn error(&mut self, v: stream::Source) -> stream::Result {
+        self.any(v)
+    }
+
+    #[inline]
     fn i64(&mut self, v: i64) -> stream::Result {
         self.i64(v)
     }
@@ -374,6 +393,17 @@ impl<'a> RefMutStream<'a> {
     #[inline]
     pub fn display(&mut self, v: impl Display) -> stream::Result {
         self.0.display(v)
+    }
+
+    /**
+    Stream an error.
+
+    This method is only available when the `std` feature is enabled.
+    */
+    #[inline]
+    #[cfg(feature = "std")]
+    pub fn error(&mut self, v: impl error::Error) -> stream::Result {
+        self.0.error(v)
     }
 
     /**

--- a/src/stream/owned.rs
+++ b/src/stream/owned.rs
@@ -574,6 +574,11 @@ impl<'a> Stream for RefMutStream<'a> {
     }
 
     #[inline]
+    fn error(&mut self, v: stream::Source) -> stream::Result {
+        self.any(v)
+    }
+
+    #[inline]
     fn i64(&mut self, v: i64) -> stream::Result {
         self.i64(v)
     }

--- a/src/stream/owned.rs
+++ b/src/stream/owned.rs
@@ -92,6 +92,26 @@ where
     Stream an error.
 
     This method is only available when the `std` feature is enabled.
+
+    # Examples
+
+    Errors that don't satisfy the trait bounds needed by this method can go through [`Source`](struct.Source.html):
+
+    ```
+    # #![cfg(feature = "std")]
+    # use sval::value::{self, Value};
+    # struct MyError {
+    #    error: std::io::Error,
+    # }
+    impl Value for MyError {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
+            use sval::stream::Source;
+
+            stream.any(Source::new(&self.error))
+        }
+    }
+    # fn main() {}
+    ```
     */
     #[inline]
     #[cfg(feature = "std")]
@@ -399,6 +419,26 @@ impl<'a> RefMutStream<'a> {
     Stream an error.
 
     This method is only available when the `std` feature is enabled.
+
+    # Examples
+
+    Errors that don't satisfy the trait bounds needed by this method can go through [`Source`](struct.Source.html):
+
+    ```
+    # #![cfg(feature = "std")]
+    # use sval::value::{self, Value};
+    # struct MyError {
+    #    error: std::io::Error,
+    # }
+    impl Value for MyError {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
+            use sval::stream::Source;
+
+            stream.any(Source::new(&self.error))
+        }
+    }
+    # fn main() {}
+    ```
     */
     #[inline]
     #[cfg(feature = "std")]

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -515,6 +515,11 @@ impl Stream for Stack {
     }
 
     #[inline]
+    fn error(&mut self, _: stream::Source) -> stream::Result {
+        self.primitive().map(|_| ())
+    }
+
+    #[inline]
     fn i64(&mut self, _: i64) -> stream::Result {
         self.primitive().map(|_| ())
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,10 +19,12 @@ mod alloc_support {
         std::{
             string::String,
             vec::Vec,
+            io,
         },
         stream::{
             OwnedStream,
             Stream,
+            Source,
         },
         value::{
             owned::Kind,
@@ -48,8 +50,12 @@ mod alloc_support {
         Bool(bool),
         Str(String),
         Char(char),
+        Error(Source),
         None,
     }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Source(String);
 
     /**
     Collect a value into a sequence of tokens.
@@ -73,6 +79,7 @@ mod alloc_support {
                 Kind::Char(v) => Some(Token::Char(v)),
                 Kind::Str(ref v) => Some(Token::Str((**v).into())),
                 Kind::None => Some(Token::None),
+                Kind::Error(err) => Some(Token::Error(Source(err.to_string()))),
                 _ => None,
             })
             .collect()
@@ -151,6 +158,7 @@ mod alloc_support {
                 ];
                 v
             }),
+            Box::new(Source::new(io::Error::from(io::ErrorKind::Other))),
         ];
 
         macro_rules! check {

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -468,12 +468,26 @@ mod tests {
                 Token,
             },
             stream::Source,
+            value::{self, Value},
         };
 
         #[test]
         fn stream_error() {
             let err = io::Error::from(io::ErrorKind::Other);
             assert_eq!(vec![Token::Error(test::Source::new(&err))], test::tokens(Source::new(&err)));
+        }
+
+        #[test]
+        fn stream_inner_error() {
+            struct MyError;
+
+            impl Value for MyError {
+                fn stream(&self, stream: &mut value::Stream) -> value::Result {
+                    stream.error(io::Error::from(io::ErrorKind::Other))
+                }
+            }
+
+            assert_eq!(vec![Token::Error(test::Source::new(&io::Error::from(io::ErrorKind::Other)))], test::tokens(MyError));
         }
 
         #[test]

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -178,6 +178,21 @@ impl<'a> Value for stream::Arguments<'a> {
     }
 }
 
+impl<'a> Value for stream::Source<'a> {
+    #[inline]
+    fn stream(&self, stream: &mut value::Stream) -> value::Result {
+        #[cfg(feature = "std")]
+        {
+            stream.error(self.to_error())
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            stream.debug(self)
+        }
+    }
+}
+
 #[cfg(feature = "alloc")]
 mod alloc_support {
     use super::*;
@@ -446,12 +461,20 @@ mod tests {
             std::{
                 collections::HashMap,
                 sync::Arc,
+                io,
             },
             test::{
                 self,
                 Token,
             },
+            stream::Source,
         };
+
+        #[test]
+        fn stream_error() {
+            let err = io::Error::from(io::ErrorKind::Other);
+            assert_eq!(vec![Token::Error], test::tokens(stream::Source::new(&err)));
+        }
 
         #[test]
         fn stream_map() {

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -183,7 +183,7 @@ impl<'a> Value for stream::Source<'a> {
     fn stream(&self, stream: &mut value::Stream) -> value::Result {
         #[cfg(feature = "std")]
         {
-            stream.error(self.to_error())
+            stream.error(self.get())
         }
 
         #[cfg(not(feature = "std"))]

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -188,7 +188,7 @@ impl<'a> Value for stream::Source<'a> {
 
         #[cfg(not(feature = "std"))]
         {
-            stream.debug(self)
+            stream.none()
         }
     }
 }
@@ -473,7 +473,7 @@ mod tests {
         #[test]
         fn stream_error() {
             let err = io::Error::from(io::ErrorKind::Other);
-            assert_eq!(vec![Token::Error], test::tokens(stream::Source::new(&err)));
+            assert_eq!(vec![Token::Error(test::Source::new(&err))], test::tokens(Source::new(&err)));
         }
 
         #[test]

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -335,7 +335,7 @@ impl<'a> From<stream::Source<'a>> for OwnedSource {
     fn from(err: stream::Source<'a>) -> OwnedSource {
         #[cfg(feature = "std")]
         {
-            OwnedSource::collect(err.get())
+            OwnedSource::collect(err.as_ref())
         }
 
         #[cfg(not(feature = "std"))]


### PR DESCRIPTION
This is a sketchy API, mostly with the `tracing` crate in mind. The `Error` trait as-is isn't very usable generically, so I don't want to commit to this until we have some idea of how we expect libraries to work with errors (either as `dyn Error` or `impl Error`).