### PR TITLE
Prepare for 1.0.0-alpha.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "sval"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval"
@@ -72,7 +72,7 @@ default-features = false
 package = "serde"
 
 [dependencies.sval_derive]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 path = "./derive"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add `sval` to your crate dependencies:
 
 ```toml
 [dependencies.sval]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 ```
 
 ## To support my data-structures
@@ -89,7 +89,7 @@ The `sval_json` crate can format any `sval::Value` as JSON:
 
 ```toml
 [dependencies.sval_json]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 features = ["std"]
 ```
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_derive"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,7 @@ This `derive` implementation has been shamelessly lifted from dtolnay's `miniser
 https://github.com/dtolnay/miniserde
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_derive/1.0.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/sval_derive/1.0.0-alpha.2")]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 documentation = "https://docs.rs/sval_json"
@@ -22,7 +22,7 @@ travis-ci = { repository = "KodrAus/sval" }
 std = ["sval/std"]
 
 [dependencies.sval]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 path = "../"
 
 [dependencies.ryu]

--- a/json/README.md
+++ b/json/README.md
@@ -25,7 +25,7 @@ Add `sval_json` to your crate dependencies:
 
 ```toml
 [dependencies.sval_json]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 ```
 
 ## To write JSON to a `fmt::Write`

--- a/json/benches/src/lib.rs
+++ b/json/benches/src/lib.rs
@@ -112,7 +112,10 @@ fn twitter_serde_to_sval(b: &mut test::Bencher) {
 fn twitter_serde_to_sval_to_serde(b: &mut test::Bencher) {
     let s = input_struct();
     b.iter(|| {
-        serde_json::to_string(&sval::serde::v1::to_serialize(sval::serde::v1::to_value(&s))).unwrap();
+        serde_json::to_string(&sval::serde::v1::to_serialize(sval::serde::v1::to_value(
+            &s,
+        )))
+        .unwrap();
     });
 }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -10,7 +10,7 @@ Add `sval_json` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval_json]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 ```
 
 # Writing JSON to `fmt::Write`
@@ -79,7 +79,7 @@ let json = sval_json::to_writer(MyWrite, 42)?;
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval_json/1.0.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/sval_json/1.0.0-alpha.2")]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/collect/mod.rs
+++ b/src/collect/mod.rs
@@ -8,8 +8,8 @@ allocating for nested datastructures that are already known.
 
 use crate::stream::{
     Arguments,
-    Stream,
     Source,
+    Stream,
 };
 
 mod owned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml,ignore
 [dependencies.sval]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 ```
 
 # Supported formats
@@ -170,7 +170,7 @@ fn with_value(value: impl Value) {
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/sval/1.0.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/sval/1.0.0-alpha.2")]
 #![no_std]
 
 #[doc(hidden)]

--- a/src/serde/v1/to_serialize.rs
+++ b/src/serde/v1/to_serialize.rs
@@ -864,7 +864,9 @@ mod alloc_support {
                     Kind::Error(ref v) => {
                         reader.expect_empty().map_err(S::Error::custom)?;
 
-                        stream::Source::from(&**v).to_serialize().serialize(serializer)
+                        stream::Source::from(&**v)
+                            .to_serialize()
+                            .serialize(serializer)
                     }
                     Kind::None => {
                         reader.expect_empty().map_err(S::Error::custom)?;

--- a/src/stream/error.rs
+++ b/src/stream/error.rs
@@ -1,8 +1,4 @@
-
-use crate::std::{
-    fmt,
-};
-
+use crate::std::fmt;
 
 /**
 A streamable error.
@@ -63,8 +59,8 @@ impl<'a> fmt::Display for Source<'a> {
 #[cfg(feature = "std")]
 mod std_support {
     use crate::std::{
-        fmt,
         error::Error,
+        fmt,
         marker::PhantomData,
         mem,
     };
@@ -158,7 +154,9 @@ mod std_support {
                     // SAFETY: We're careful not to expose the actual value with the fake lifetime
                     // Calling code can only interact with it through an arbitrarily short borrow
                     // that's bound to `'a` from `self`, which is the real McCoy lifetime of the error
-                    extended: ExtendedLifetimeError(unsafe { mem::transmute::<&'a dyn Error, &'static dyn Error>(err) }),
+                    extended: ExtendedLifetimeError(unsafe {
+                        mem::transmute::<&'a dyn Error, &'static dyn Error>(err)
+                    }),
                     _marker: PhantomData,
                 },
             }

--- a/src/stream/fmt.rs
+++ b/src/stream/fmt.rs
@@ -1,7 +1,4 @@
-use crate::std::{
-    fmt,
-};
-
+use crate::std::fmt;
 
 /**
 A formattable value.
@@ -18,7 +15,7 @@ impl<'a> Arguments<'a> {
     /**
     Capture standard format arguments.
 
-    Prefer the [`debug`](#method.debug) and [`display`](#method.display) methods to create 
+    Prefer the [`debug`](#method.debug) and [`display`](#method.display) methods to create
     `Arguments` over passing them through `format_args`,
     because `format_args` will clobber any flags a stream
     might want to format these arguments with.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -202,21 +202,20 @@ structures aren't supported. See the [`stream::Stack`] type for more details.
 [`stream::Stack`]: stack/struct.Stack.html
 */
 
-mod fmt;
 mod error;
+mod fmt;
 pub(crate) mod owned;
 pub mod stack;
 
 pub use self::{
+    error::Source,
+    fmt::Arguments,
     owned::{
         OwnedStream,
         RefMutStream,
     },
     stack::Stack,
-    fmt::Arguments,
-    error::Source,
 };
-
 
 /**
 A receiver for the structure of a value.

--- a/src/test.rs
+++ b/src/test.rs
@@ -17,9 +17,9 @@ a breaking `semver` change.
 mod alloc_support {
     use crate::{
         std::{
+            fmt,
             string::String,
             vec::Vec,
-            fmt,
         },
         stream::{
             self,
@@ -27,7 +27,10 @@ mod alloc_support {
             Stream,
         },
         value::{
-            owned::{Kind, OwnedSource},
+            owned::{
+                Kind,
+                OwnedSource,
+            },
             OwnedValue,
             Value,
         },

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -460,21 +460,27 @@ mod tests {
         use crate::{
             std::{
                 collections::HashMap,
-                sync::Arc,
                 io,
+                sync::Arc,
             },
+            stream::Source,
             test::{
                 self,
                 Token,
             },
-            stream::Source,
-            value::{self, Value},
+            value::{
+                self,
+                Value,
+            },
         };
 
         #[test]
         fn stream_error() {
             let err = io::Error::from(io::ErrorKind::Other);
-            assert_eq!(vec![Token::Error(test::Source::new(&err))], test::tokens(Source::new(&err)));
+            assert_eq!(
+                vec![Token::Error(test::Source::new(&err))],
+                test::tokens(Source::new(&err))
+            );
         }
 
         #[test]
@@ -487,7 +493,12 @@ mod tests {
                 }
             }
 
-            assert_eq!(vec![Token::Error(test::Source::new(&io::Error::from(io::ErrorKind::Other)))], test::tokens(MyError));
+            assert_eq!(
+                vec![Token::Error(test::Source::new(&io::Error::from(
+                    io::ErrorKind::Other
+                )))],
+                test::tokens(MyError)
+            );
         }
 
         #[test]

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -735,27 +735,29 @@ impl OwnedValue {
 #[cfg(feature = "std")]
 mod std_support {
     use super::{
-        OwnedSource,
         Container,
+        OwnedSource,
     };
 
-    use crate::std::{
-        error::Error,
-    };
+    use crate::std::error::Error;
 
     impl OwnedSource {
         pub(crate) fn collect(err: &dyn Error) -> Self {
             OwnedSource {
                 debug: format!("{:?}", err),
                 display: format!("{}", err),
-                source: err.source().map(|source| Container::from(OwnedSource::collect(source))),
+                source: err
+                    .source()
+                    .map(|source| Container::from(OwnedSource::collect(source))),
             }
         }
     }
 
     impl Error for OwnedSource {
         fn source(&self) -> Option<&(dyn Error + 'static)> {
-            self.source.as_ref().map(|source| &**source as &(dyn Error + 'static))
+            self.source
+                .as_ref()
+                .map(|source| &**source as &(dyn Error + 'static))
         }
     }
 }
@@ -874,12 +876,7 @@ mod tests {
         fn owned_error() {
             let v = test::tokens(stream::Source::empty());
 
-            assert_eq!(
-                vec![
-                    Token::None,
-                ],
-                v
-            );
+            assert_eq!(vec![Token::None,], v);
         }
     }
 
@@ -887,7 +884,11 @@ mod tests {
     mod std_support {
         use super::*;
 
-        use crate::std::{io, error, fmt};
+        use crate::std::{
+            error,
+            fmt,
+            io,
+        };
 
         #[test]
         fn owned_error() {
@@ -916,12 +917,7 @@ mod tests {
 
             let v = test::tokens(stream::Source::new(&err));
 
-            assert_eq!(
-                vec![
-                    Token::Error(test::Source::new(&err)),
-                ],
-                v
-            );
+            assert_eq!(vec![Token::Error(test::Source::new(&err)),], v);
         }
     }
 }


### PR DESCRIPTION
Includes:
- #96 

This is a new API, so it'll need some time to be used before stabilizing.