### PR TITLE
Fix incorrect feature for serde1 with std

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -8,15 +8,19 @@ cargo test
 
 printf "\n\n---- sval with std ----\n\n"
 cargo test --features std
+cargo test --features "std fmt"
+cargo test --features "std serde1"
 
 printf "\n\n---- sval with alloc ----\n\n"
 cargo test --lib --features alloc
+cargo test --features "alloc fmt"
+cargo test --features "alloc serde1"
 
 printf "\n\n---- sval with fmt ----\n\n"
 cargo test --features fmt
 
-printf "\n\n---- sval with serde ----\n\n"
-cargo test --features serde
+printf "\n\n---- sval with serde1 ----\n\n"
+cargo test --features serde1
 
 printf "\n\n---- sval with all features in release mode ----\n\n"
 cargo test --all-features --release

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -701,7 +701,7 @@ impl Stream for Primitive {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde1")]
 impl Buf {
     pub(crate) fn clear(&mut self) {
         self.tokens.clear();


### PR DESCRIPTION
Compiling with both the `std` and `serde1` features would fail because we had an invalid feature gate for the blanket `serde` feature. I've added a few more feature combinations to our CI.