### PR TITLE
Always use &dyn Error + 'static

### DIFF
--- a/src/collect/owned.rs
+++ b/src/collect/owned.rs
@@ -49,8 +49,8 @@ where
 
     #[inline]
     #[cfg(feature = "std")]
-    pub fn error(&mut self, v: impl error::Error) -> collect::Result {
-        self.stream.error(Source::from(&v as &dyn error::Error))
+    pub fn error(&mut self, v: &(dyn error::Error + 'static)) -> collect::Result {
+        self.stream.error(Source::from(v))
     }
 
     #[inline]
@@ -175,7 +175,7 @@ impl<'a> RefMutCollect<'a> {
 
     #[inline]
     #[cfg(feature = "std")]
-    pub fn error(&mut self, v: impl error::Error) -> collect::Result {
+    pub fn error(&mut self, v: &(dyn error::Error + 'static)) -> collect::Result {
         self.0.error(v)
     }
 

--- a/src/stream/owned.rs
+++ b/src/stream/owned.rs
@@ -115,7 +115,7 @@ where
     */
     #[inline]
     #[cfg(feature = "std")]
-    pub fn error(&mut self, v: impl error::Error) -> stream::Result {
+    pub fn error(&mut self, v: &(dyn error::Error + 'static)) -> stream::Result {
         self.0.error(v)
     }
 
@@ -442,7 +442,7 @@ impl<'a> RefMutStream<'a> {
     */
     #[inline]
     #[cfg(feature = "std")]
-    pub fn error(&mut self, v: impl error::Error) -> stream::Result {
+    pub fn error(&mut self, v: &(dyn error::Error + 'static)) -> stream::Result {
         self.0.error(v)
     }
 

--- a/src/value/impls.rs
+++ b/src/value/impls.rs
@@ -489,7 +489,7 @@ mod tests {
 
             impl Value for MyError {
                 fn stream(&self, stream: &mut value::Stream) -> value::Result {
-                    stream.error(io::Error::from(io::ErrorKind::Other))
+                    stream.error(&io::Error::from(io::ErrorKind::Other))
                 }
             }
 


### PR DESCRIPTION
This makes us always require our captured error types can produce a `&(dyn Error + 'static)`, which seems to be the most consistent abstract error type.