### PR TITLE
include LICENSE files in sval_json

### DIFF
--- a/json/LICENSE-APACHE
+++ b/json/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/json/LICENSE-MIT
+++ b/json/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Since those symlinks are already included in the sval_derive crate, it looks like it was just an oversight that they were not present in the sval_json crate as well.