### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde1 = ["serde1_lib"]
 test = ["std"]
 
 [dependencies.serde1_lib]
-version = "1.0.104"
+version = "1.0.147"
 optional = true
 default-features = false
 package = "serde"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -26,6 +26,4 @@ path = "../"
 version = "1"
 
 [dependencies.itoa]
-version = "0.4"
-features = ["i128"]
-default-features = false
+version = "1"

--- a/stack/Cargo.toml
+++ b/stack/Cargo.toml
@@ -23,4 +23,4 @@ default-features = false
 optional = true
 
 [dev-dependencies.quickcheck]
-version = "0.9"
+version = "1"


### PR DESCRIPTION
`itoa`: `0.4` -> `1`
`quickcheck`: `0.9` -> `1`
`serde`: `1.0.104` -> `1.0.147`