### PR TITLE
Add a few missing methods and document data model a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ self-describing formats:
 3. Borrowing is an optional optimization.
 4. The core data model is small, with tags for extensibility.
 
+# Data-model
+
+- Values:
+    - `null`: the absence of any other meaningful value.
+    - Booleans: `true` and `false`.
+    - Text strings: stream of UTF8-encoded bytes.
+    - Binary strings: stream of arbtirary bytes.
+    - Numbers:
+        - Integers: `u8`-`u128`, `i8`-`i128`.
+        - Binary floating point: `f32`-`f64`.
+    - Maps: heterogeneous collection of key-value pairs.
+    - Sequences: heterogeneous collection of values.
+    - Tags: out-of-band type hints.
+    - Tagged values: a tag associated with a value.
+    - Records: tagged maps where keys are well-known labels.
+    - Tuples: tagged sequences.
+    - Enums: tagged variants, where variants are enums, tags, tagged values, records, or tuples.
+
+`sval` includes built-in tags that extend its data-model with some common datatypes:
+
+- Rust primitives:
+    - `()`.
+    - `Option<T>`.
+- Arbitrary-precision decimal floating point numbers.
+
+Other built-in tags may be added in the future. Libraries may also define their own tags.
+
 ## Current status
 
 This project has a complete and stable API, but isn't well documented yet.

--- a/buffer/src/fragments.rs
+++ b/buffer/src/fragments.rs
@@ -109,6 +109,13 @@ impl<'sval> TextBuf<'sval> {
     }
 
     /**
+    Clear the text buffer so it can be re-used.
+    */
+    pub fn clear(&mut self) {
+        *self = Default::default();
+    }
+
+    /**
     Push a borrowed text fragment onto the buffer.
     */
     pub fn push_fragment(&mut self, fragment: &'sval str) -> Result<(), Error> {
@@ -279,6 +286,13 @@ impl<'sval> BinaryBuf<'sval> {
             .map_err(|_| collector.err.unwrap())?;
 
         Ok(collector.buf)
+    }
+
+    /**
+    Clear the binary buffer so it can be re-used.
+    */
+    pub fn clear(&mut self) {
+        *self = Default::default();
     }
 
     /**
@@ -457,9 +471,7 @@ impl<'sval, T: ?Sized + Fragment> FragmentBuf<'sval, T> {
             value: value.to_fragment(),
         }
     }
-}
 
-impl<'sval, T: ?Sized + Fragment> FragmentBuf<'sval, T> {
     fn push(&mut self, fragment: &'sval T) -> Result<(), Error> {
         if self.value.can_replace() {
             self.value = fragment.to_fragment();
@@ -541,6 +553,16 @@ mod tests {
     }
 
     #[test]
+    fn text_fragment_clear() {
+        let mut buf = TextBuf::new();
+
+        buf.push_fragment("abc").unwrap();
+        buf.clear();
+
+        assert_eq!("", buf.as_str());
+    }
+
+    #[test]
     fn binary_fragment_replace() {
         let mut buf = BinaryBuf::new();
 
@@ -551,6 +573,16 @@ mod tests {
 
         assert_eq!(b"abc", buf.as_slice());
         assert_eq!(Some(b"abc" as &[u8]), buf.as_borrowed_slice());
+    }
+
+    #[test]
+    fn binary_fragment_clear() {
+        let mut buf = BinaryBuf::new();
+
+        buf.push_fragment(b"abc").unwrap();
+        buf.clear();
+
+        assert_eq!(b"", buf.as_slice());
     }
 
     #[test]

--- a/fmt/src/to_fmt.rs
+++ b/fmt/src/to_fmt.rs
@@ -27,16 +27,21 @@ impl<V: sval::Value + ?Sized> ToFmt<V> {
     }
 }
 
+/**
+Format a value into an underlying formatter.
+*/
+pub fn stream_to_fmt(fmt: &mut fmt::Formatter, v: impl sval::Value) -> fmt::Result {
+    v.stream(&mut Writer::new(fmt)).map_err(|_| fmt::Error)
+}
+
 impl<V: sval::Value> fmt::Debug for ToFmt<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.stream(&mut Writer::new(f)).map_err(|_| fmt::Error)?;
-
-        Ok(())
+        stream_to_fmt(f, &self.0)
     }
 }
 
 impl<V: sval::Value> fmt::Display for ToFmt<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        stream_to_fmt(f, &self.0)
     }
 }


### PR DESCRIPTION
This PR just adds a few missing methods to `sval_buffer` based on usage and adds some basic doc in the readme on its data-model. I'll do a full pass over the docs soon.