### PR TITLE
Prepare for 2.1.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/buffer/Cargo.toml
+++ b/buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_buffer"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -20,17 +20,17 @@ std = ["alloc", "sval/std"]
 alloc = ["sval/alloc"]
 
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 path = "../"
 
 [dependencies.sval_ref]
-version = "2.1.0"
+version = "2.1.1"
 path = "../ref"
 
 [dev-dependencies.sval_derive]
-version = "2.1.0"
+version = "2.1.1"
 path = "../derive"
 
 [dev-dependencies.sval_test]
-version = "2.1.0"
+version = "2.1.1"
 path = "../test"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/dynamic/Cargo.toml
+++ b/dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_dynamic"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -12,5 +12,5 @@ keywords = ["serialization", "no_std"]
 categories = ["encoding", "no-std"]
 
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 path = "../"

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_fmt"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -19,7 +19,7 @@ std = ["alloc", "sval/std"]
 alloc = ["sval/alloc"]
 
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 path = "../"
 
 [dependencies.ryu]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -19,7 +19,7 @@ std = ["alloc", "sval/std"]
 alloc = ["sval/alloc"]
 
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 path = "../"
 
 [dependencies.ryu]

--- a/ref/Cargo.toml
+++ b/ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_ref"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -16,9 +16,9 @@ std = ["alloc", "sval/std"]
 alloc = ["sval/alloc"]
 
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 path = "../"
 
 [dev-dependencies.sval_test]
-version = "2.1.0"
+version = "2.1.1"
 path = "../test"

--- a/ref/README.md
+++ b/ref/README.md
@@ -1,0 +1,7 @@
+# `sval_ref`
+
+[![Rust](https://github.com/sval-rs/sval/workflows/ref/badge.svg)](https://github.com/sval-rs/sval/actions)
+[![Latest version](https://img.shields.io/crates/v/sval.svg)](https://crates.io/crates/sval_ref)
+[![Documentation Latest](https://docs.rs/sval_ref/badge.svg)](https://docs.rs/sval_ref)
+
+A variant of `sval::Value` for types with internal references.

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_serde"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -19,16 +19,16 @@ std = ["alloc", "serde/std", "sval/std", "sval_buffer/std"]
 alloc = ["serde/alloc", "sval/alloc", "sval_buffer/alloc"]
 
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 path = "../"
 
 [dependencies.sval_buffer]
-version = "2.1.0"
+version = "2.1.1"
 path = "../buffer"
 default-features = false
 
 [dependencies.sval_fmt]
-version = "2.1.0"
+version = "2.1.1"
 path = "../fmt"
 
 [dependencies.serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 ```
 
 By default, `sval` doesn't depend on Rust's standard library or integrate
@@ -24,7 +24,7 @@ with its collection types. To include them, add the `alloc` or `std` features:
 
 ```toml
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 features = ["std"]
 ```
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_test"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -12,10 +12,10 @@ keywords = ["serialization", "no_std"]
 categories = ["encoding", "no-std"]
 
 [dependencies.sval]
-version = "2.1.0"
+version = "2.1.1"
 path = "../"
 features = ["std"]
 
 [dev-dependencies.sval_dynamic]
-version = "2.1.0"
+version = "2.1.1"
 path = "../dynamic"


### PR DESCRIPTION
Adds a README to `sval_ref`, which was missed in #127 