### PR TITLE
Add stream_display and derive to root lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,13 @@ members = [
 std = ["alloc"]
 alloc = []
 
+derive = ["dep:sval_derive"]
+
+[dependencies.sval_derive]
+version = "2.1.1"
+path = "derive"
+optional = true
+
 [dev-dependencies.sval_derive]
 path = "derive"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,9 @@ mod std {
 #[cfg(all(not(feature = "alloc"), not(feature = "std")))]
 extern crate core as std;
 
+#[cfg(feature = "derive")]
+pub use sval_derive::*;
+
 mod data;
 mod result;
 mod stream;


### PR DESCRIPTION
This PR adds two fairly fundamental features to the root `sval` library to make it easier to use:

1. `#[derive]` support. It's common these days for libraries to re-export their custom derives under a `derive` feature.
2. `stream_display`. An adapter that datatypes that stream as tagged text, such as big numbers, can use to avoid needing to pull in `sval_fmt` or write the glue code themselves.