### PR TITLE
Support converting buffered values into fully owned ones

### DIFF
--- a/.github/workflows/buffer.yml
+++ b/.github/workflows/buffer.yml
@@ -27,6 +27,27 @@ jobs:
         working-directory: ./buffer
         run: cargo hack test --feature-powerset
 
+  bench:
+    name: Bench
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+
+      - name: Powerset
+        working-directory: ./buffer
+        run: cargo hack bench --feature-powerset --no-run
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/buffer/benches/value.rs
+++ b/buffer/benches/value.rs
@@ -12,7 +12,11 @@ struct OwnedData {
 
 #[cfg(feature = "alloc")]
 fn owned_data() -> OwnedData {
-    OwnedData { id:  42, title: "A very important document".to_owned(), attributes: vec!["#1".to_owned(), "#2".to_owned(), "#3".to_owned()] }
+    OwnedData {
+        id: 42,
+        title: "A very important document".to_owned(),
+        attributes: vec!["#1".to_owned(), "#2".to_owned(), "#3".to_owned()],
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -25,7 +29,11 @@ struct BorrowedData<'a> {
 
 #[cfg(feature = "alloc")]
 fn borrowed_data() -> BorrowedData<'static> {
-    BorrowedData { id:  42, title: "A very important document", attributes: &["#1", "#2", "#3"] }
+    BorrowedData {
+        id: 42,
+        title: "A very important document",
+        attributes: &["#1", "#2", "#3"],
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -57,7 +65,10 @@ fn borrowed_collect(b: &mut test::Bencher) {
 fn borrowed_collect_ref_to_owned(b: &mut test::Bencher) {
     b.iter(|| {
         let data = borrowed_data();
-        sval_buffer::ValueBuf::collect(&data).unwrap().into_owned().unwrap()
+        sval_buffer::ValueBuf::collect(&data)
+            .unwrap()
+            .into_owned()
+            .unwrap()
     })
 }
 
@@ -66,10 +77,12 @@ fn borrowed_collect_ref_to_owned(b: &mut test::Bencher) {
 fn borrowed_collect_to_owned(b: &mut test::Bencher) {
     b.iter(|| {
         let data = borrowed_data();
-        sval_buffer::ValueBuf::collect_owned(&data).unwrap().into_owned().unwrap()
+        sval_buffer::ValueBuf::collect_owned(&data)
+            .unwrap()
+            .into_owned()
+            .unwrap()
     })
 }
-
 
 #[cfg(feature = "alloc")]
 #[bench]
@@ -100,7 +113,10 @@ fn owned_collect(b: &mut test::Bencher) {
 fn owned_collect_ref_to_owned(b: &mut test::Bencher) {
     b.iter(|| {
         let data = owned_data();
-        sval_buffer::ValueBuf::collect(&data).unwrap().into_owned().unwrap()
+        sval_buffer::ValueBuf::collect(&data)
+            .unwrap()
+            .into_owned()
+            .unwrap()
     })
 }
 
@@ -109,6 +125,9 @@ fn owned_collect_ref_to_owned(b: &mut test::Bencher) {
 fn owned_collect_to_owned(b: &mut test::Bencher) {
     b.iter(|| {
         let data = owned_data();
-        sval_buffer::ValueBuf::collect_owned(&data).unwrap().into_owned().unwrap()
+        sval_buffer::ValueBuf::collect_owned(&data)
+            .unwrap()
+            .into_owned()
+            .unwrap()
     })
 }

--- a/buffer/benches/value.rs
+++ b/buffer/benches/value.rs
@@ -16,6 +16,62 @@ fn owned_data() -> OwnedData {
 }
 
 #[cfg(feature = "alloc")]
+#[derive(sval_derive::Value)]
+struct BorrowedData<'a> {
+    id: i32,
+    title: &'a str,
+    attributes: &'a [&'a str],
+}
+
+#[cfg(feature = "alloc")]
+fn borrowed_data() -> BorrowedData<'static> {
+    BorrowedData { id:  42, title: "A very important document", attributes: &["#1", "#2", "#3"] }
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn borrowed(b: &mut test::Bencher) {
+    b.iter(|| borrowed_data())
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn borrowed_collect_ref(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = borrowed_data();
+        test::black_box(sval_buffer::ValueBuf::collect(&data).unwrap());
+    })
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn borrowed_collect(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = borrowed_data();
+        test::black_box(sval_buffer::ValueBuf::collect_owned(data).unwrap());
+    })
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn borrowed_collect_ref_to_owned(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = borrowed_data();
+        sval_buffer::ValueBuf::collect(&data).unwrap().into_owned().unwrap()
+    })
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn borrowed_collect_to_owned(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = borrowed_data();
+        sval_buffer::ValueBuf::collect_owned(&data).unwrap().into_owned().unwrap()
+    })
+}
+
+
+#[cfg(feature = "alloc")]
 #[bench]
 fn owned(b: &mut test::Bencher) {
     b.iter(|| owned_data())

--- a/buffer/benches/value.rs
+++ b/buffer/benches/value.rs
@@ -1,0 +1,58 @@
+#![feature(test)]
+
+extern crate test;
+
+#[cfg(feature = "alloc")]
+#[derive(sval_derive::Value)]
+struct OwnedData {
+    id: i32,
+    title: String,
+    attributes: Vec<String>,
+}
+
+#[cfg(feature = "alloc")]
+fn owned_data() -> OwnedData {
+    OwnedData { id:  42, title: "A very important document".to_owned(), attributes: vec!["#1".to_owned(), "#2".to_owned(), "#3".to_owned()] }
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn owned(b: &mut test::Bencher) {
+    b.iter(|| owned_data())
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn owned_collect_ref(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = owned_data();
+        test::black_box(sval_buffer::ValueBuf::collect(&data).unwrap());
+    })
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn owned_collect(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = owned_data();
+        test::black_box(sval_buffer::ValueBuf::collect_owned(data).unwrap());
+    })
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn owned_collect_ref_to_owned(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = owned_data();
+        sval_buffer::ValueBuf::collect(&data).unwrap().into_owned().unwrap()
+    })
+}
+
+#[cfg(feature = "alloc")]
+#[bench]
+fn owned_collect_to_owned(b: &mut test::Bencher) {
+    b.iter(|| {
+        let data = owned_data();
+        sval_buffer::ValueBuf::collect_owned(&data).unwrap().into_owned().unwrap()
+    })
+}

--- a/buffer/src/error.rs
+++ b/buffer/src/error.rs
@@ -14,6 +14,8 @@ enum ErrorKind {
     },
     #[cfg(feature = "alloc")]
     OutsideContainer { method: &'static str },
+    #[cfg(feature = "alloc")]
+    InvalidValue { reason: &'static str },
     #[cfg(not(feature = "alloc"))]
     NoAlloc { method: &'static str },
 }
@@ -27,6 +29,10 @@ impl fmt::Display for Error {
             #[cfg(feature = "alloc")]
             ErrorKind::OutsideContainer { method } => {
                 write!(f, "expected a fragment while buffering {}", method)
+            }
+            #[cfg(feature = "alloc")]
+            ErrorKind::InvalidValue { reason } => {
+                write!(f, "the value being buffered is invalid: {}", reason)
             }
             #[cfg(not(feature = "alloc"))]
             ErrorKind::NoAlloc { method } => write!(f, "cannot allocate for {}", method),
@@ -42,6 +48,11 @@ impl Error {
     #[cfg(feature = "alloc")]
     pub(crate) fn outside_container(method: &'static str) -> Self {
         Error(ErrorKind::OutsideContainer { method })
+    }
+
+    #[cfg(feature = "alloc")]
+    pub(crate) fn invalid_value(reason: &'static str) -> Self {
+        Error(ErrorKind::InvalidValue { reason })
     }
 
     #[cfg(not(feature = "alloc"))]

--- a/buffer/src/fragments.rs
+++ b/buffer/src/fragments.rs
@@ -153,6 +153,7 @@ impl<'sval> TextBuf<'sval> {
     pub(crate) fn into_owned_in_place(&mut self) -> &mut TextBuf<'static> {
         crate::assert_static(self.0.into_owned_in_place());
 
+        // SAFETY: `self` no longer contains any data borrowed for `'sval`
         unsafe { mem::transmute::<&mut TextBuf<'sval>, &mut TextBuf<'static>>(self) }
     }
 }

--- a/buffer/src/lib.rs
+++ b/buffer/src/lib.rs
@@ -39,4 +39,7 @@ mod std {
 mod fragments;
 mod value;
 
+#[cfg(feature = "alloc")]
+fn assert_static<T: 'static>(_: &mut T) {}
+
 pub use self::{error::*, fragments::*, value::*};

--- a/buffer/src/value.rs
+++ b/buffer/src/value.rs
@@ -193,7 +193,7 @@ impl ValueBuf<'static> {
 
     This method will fail if the `alloc` feature is not enabled.
     */
-    pub fn collect_owned(v: &(impl sval::Value + ?Sized)) -> Result<Self, Error> {
+    pub fn collect_owned(v: impl sval::Value) -> Result<Self, Error> {
         let mut buf = ValueBuf::new();
 
         // Buffering the value as computed means any borrowed data will
@@ -254,7 +254,7 @@ impl Value<'static> {
 
     This method will fail if the `alloc` feature is not enabled.
     */
-    pub fn collect_owned(v: &(impl sval::Value + ?Sized)) -> Result<Self, Error> {
+    pub fn collect_owned(v: impl sval::Value) -> Result<Self, Error> {
         ValueBuf::collect_owned(v).map(|buf| buf.value)
     }
 }

--- a/buffer/src/value.rs
+++ b/buffer/src/value.rs
@@ -1,7 +1,10 @@
 use crate::{std::marker::PhantomData, Error};
 
 #[cfg(feature = "alloc")]
-use crate::{std::vec::Vec, BinaryBuf, TextBuf};
+use crate::{
+    std::{mem, vec::Vec},
+    BinaryBuf, TextBuf,
+};
 
 use sval_ref::ValueRef as _;
 
@@ -125,6 +128,48 @@ impl<'sval> ValueBuf<'sval> {
         self.value.clone()
     }
 
+    /**
+    Convert this buffer into an immutable value.
+    */
+    pub fn into_value(self) -> Value<'sval> {
+        self.value
+    }
+
+    /**
+    Fully buffer any borrowed data, returning a buffer that doesn't borrow anything.
+
+    This method will fail if the `alloc` feature is not enabled.
+    */
+    pub fn into_owned(self) -> Result<ValueBuf<'static>, Error> {
+        #[cfg(feature = "alloc")]
+        {
+            let ValueBuf {
+                value,
+                mut stack,
+                mut is_in_text_or_binary,
+                mut err,
+            } = self;
+
+            let mut value = value.into_owned()?;
+
+            crate::assert_static(&mut value);
+            crate::assert_static(&mut stack);
+            crate::assert_static(&mut is_in_text_or_binary);
+            crate::assert_static(&mut err);
+
+            Ok(ValueBuf {
+                value,
+                stack,
+                is_in_text_or_binary,
+                err,
+            })
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            Err(Error::no_alloc("buffered value"))
+        }
+    }
+
     #[cfg(feature = "alloc")]
     fn try_catch(
         &mut self,
@@ -142,6 +187,24 @@ impl<'sval> ValueBuf<'sval> {
     }
 }
 
+impl ValueBuf<'static> {
+    /**
+    Fully buffer a value, including any internal borrowed data.
+
+    This method will fail if the `alloc` feature is not enabled.
+    */
+    pub fn collect_owned(v: &(impl sval::Value + ?Sized)) -> Result<Self, Error> {
+        let mut buf = ValueBuf::new();
+
+        // Buffering the value as computed means any borrowed data will
+        // have to be converted into owned anyways
+        match sval::stream_computed(&mut buf, v) {
+            Ok(()) => Ok(buf),
+            Err(_) => Err(buf.err.unwrap()),
+        }
+    }
+}
+
 impl<'sval> Value<'sval> {
     /**
     Buffer a value.
@@ -150,6 +213,49 @@ impl<'sval> Value<'sval> {
     */
     pub fn collect(v: &'sval (impl sval::Value + ?Sized)) -> Result<Self, Error> {
         ValueBuf::collect(v).map(|buf| buf.value)
+    }
+
+    /**
+    Fully buffer this value, including any internal borrowed data.
+
+    This method will fail if the `alloc` feature is not enabled.
+    */
+    pub fn into_owned(self) -> Result<Value<'static>, Error> {
+        #[cfg(feature = "alloc")]
+        {
+            let Value { mut parts, _marker } = self;
+
+            // Re-assign all parts within the value in-place without re-allocating for them
+            // This will take care of converted any actually borrowed data into owned
+            for part in &mut parts {
+                crate::assert_static(part.into_owned_in_place());
+            }
+
+            // SAFETY: `parts` no longer contains any data borrowed for `'sval`
+            let mut parts =
+                unsafe { mem::transmute::<Vec<ValuePart<'sval>>, Vec<ValuePart<'static>>>(parts) };
+            crate::assert_static(&mut parts);
+
+            Ok(Value {
+                parts,
+                _marker: PhantomData,
+            })
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            Err(Error::no_alloc("buffered value"))
+        }
+    }
+}
+
+impl Value<'static> {
+    /**
+    Fully buffer a value, including any internal borrowed data.
+
+    This method will fail if the `alloc` feature is not enabled.
+    */
+    pub fn collect_owned(v: &(impl sval::Value + ?Sized)) -> Result<Self, Error> {
+        ValueBuf::collect_owned(v).map(|buf| buf.value)
     }
 }
 
@@ -532,9 +638,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     fn map_key_end(&mut self) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -558,9 +662,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     fn map_value_end(&mut self) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -571,9 +673,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     fn map_end(&mut self) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -614,9 +714,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     fn seq_value_end(&mut self) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -627,9 +725,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     fn seq_end(&mut self) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -669,9 +765,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     ) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -711,9 +805,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     ) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -792,9 +884,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     fn record_value_end(&mut self, _: Option<&sval::Tag>, _: &sval::Label) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -810,9 +900,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     ) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -868,9 +956,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     fn tuple_value_end(&mut self, _: Option<&sval::Tag>, _: &sval::Index) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -886,9 +972,7 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
     ) -> sval::Result {
         #[cfg(feature = "alloc")]
         {
-            self.push_end();
-
-            Ok(())
+            self.try_catch(|buf| buf.push_end())
         }
         #[cfg(not(feature = "alloc"))]
         {
@@ -1011,9 +1095,11 @@ mod alloc_support {
             self.value.parts.push(ValuePart { kind });
         }
 
-        pub(super) fn push_end(&mut self) {
-            // TODO: Error here
-            let index = self.stack.pop().expect("missing stack frame");
+        pub(super) fn push_end(&mut self) -> Result<(), Error> {
+            let index = self
+                .stack
+                .pop()
+                .ok_or_else(|| Error::invalid_value("unbalanced calls to `begin` and `end`"))?;
 
             let len = self.value.parts.len() - index - 1;
 
@@ -1045,8 +1131,12 @@ mod alloc_support {
                 | ValueKind::F64(_)
                 | ValueKind::Text(_)
                 | ValueKind::Binary(_)
-                | ValueKind::Tag { .. } => panic!("can't end at this index"),
+                | ValueKind::Tag { .. } => {
+                    return Err(Error::invalid_value("can't end at this index"))
+                }
             } = len;
+
+            Ok(())
         }
 
         pub(super) fn current_mut(&mut self) -> &mut ValuePart<'sval> {
@@ -1078,6 +1168,116 @@ mod alloc_support {
             unsafe {
                 mem::transmute::<&'a [ValuePart<'sval>], &'a ValueSlice<'sval>>(&self.0[range])
             }
+        }
+    }
+
+    impl<'sval> ValuePart<'sval> {
+        pub(super) fn into_owned_in_place(&mut self) -> &mut ValuePart<'static> {
+            let ValuePart { kind } = self;
+
+            match kind {
+                ValueKind::Text(ref mut text) => crate::assert_static(text.into_owned_in_place()),
+                ValueKind::Binary(ref mut binary) => {
+                    crate::assert_static(binary.into_owned_in_place())
+                }
+                ValueKind::Null => (),
+                ValueKind::Bool(v) => crate::assert_static(v),
+                ValueKind::U8(v) => crate::assert_static(v),
+                ValueKind::U16(v) => crate::assert_static(v),
+                ValueKind::U32(v) => crate::assert_static(v),
+                ValueKind::U64(v) => crate::assert_static(v),
+                ValueKind::U128(v) => crate::assert_static(v),
+                ValueKind::I8(v) => crate::assert_static(v),
+                ValueKind::I16(v) => crate::assert_static(v),
+                ValueKind::I32(v) => crate::assert_static(v),
+                ValueKind::I64(v) => crate::assert_static(v),
+                ValueKind::I128(v) => crate::assert_static(v),
+                ValueKind::F32(v) => crate::assert_static(v),
+                ValueKind::F64(v) => crate::assert_static(v),
+                ValueKind::Map {
+                    len,
+                    num_entries_hint,
+                } => {
+                    crate::assert_static(len);
+                    crate::assert_static(num_entries_hint)
+                }
+                ValueKind::MapKey { len } => crate::assert_static(len),
+                ValueKind::MapValue { len } => crate::assert_static(len),
+                ValueKind::Seq {
+                    len,
+                    num_entries_hint,
+                } => {
+                    crate::assert_static(len);
+                    crate::assert_static(num_entries_hint)
+                }
+                ValueKind::SeqValue { len } => crate::assert_static(len),
+                ValueKind::Tag { tag, label, index } => {
+                    crate::assert_static(tag);
+                    crate::assert_static(label);
+                    crate::assert_static(index)
+                }
+                ValueKind::Enum {
+                    len,
+                    tag,
+                    label,
+                    index,
+                } => {
+                    crate::assert_static(len);
+                    crate::assert_static(tag);
+                    crate::assert_static(label);
+                    crate::assert_static(index)
+                }
+                ValueKind::Tagged {
+                    len,
+                    tag,
+                    label,
+                    index,
+                } => {
+                    crate::assert_static(len);
+                    crate::assert_static(tag);
+                    crate::assert_static(label);
+                    crate::assert_static(index)
+                }
+                ValueKind::Record {
+                    len,
+                    tag,
+                    label,
+                    index,
+                    num_entries,
+                } => {
+                    crate::assert_static(len);
+                    crate::assert_static(tag);
+                    crate::assert_static(label);
+                    crate::assert_static(index);
+                    crate::assert_static(num_entries)
+                }
+                ValueKind::RecordValue { len, tag, label } => {
+                    crate::assert_static(len);
+                    crate::assert_static(tag);
+                    crate::assert_static(label)
+                }
+                ValueKind::Tuple {
+                    len,
+                    tag,
+                    label,
+                    index,
+                    num_entries,
+                } => {
+                    crate::assert_static(len);
+                    crate::assert_static(tag);
+                    crate::assert_static(label);
+                    crate::assert_static(index);
+                    crate::assert_static(num_entries)
+                }
+                ValueKind::TupleValue { len, tag, index } => {
+                    crate::assert_static(len);
+                    crate::assert_static(tag);
+                    crate::assert_static(index)
+                }
+            }
+
+            // SAFETY: `self` no longer contains any data borrowed for `'sval`
+            unsafe { mem::transmute::<&mut ValuePart<'sval>, &mut ValuePart<'static>>(self) }
         }
     }
 
@@ -1267,7 +1467,7 @@ mod alloc_support {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::std::vec;
+        use crate::std::{string::String, vec};
 
         use sval::Stream as _;
         use sval_derive::*;
@@ -1815,6 +2015,44 @@ mod alloc_support {
             buf.bool(true).unwrap();
 
             assert_eq!(Value::collect(&true).unwrap().parts, buf.to_value().parts);
+        }
+
+        #[test]
+        fn into_owned() {
+            let short_lived = String::from("abc");
+
+            let buf = ValueBuf::collect(&short_lived).unwrap();
+            let borrowed_ptr = buf.value.parts.as_ptr() as *const ();
+
+            let owned = buf.into_owned().unwrap();
+            let owned_ptr = owned.value.parts.as_ptr() as *const ();
+            drop(short_lived);
+
+            assert!(core::ptr::eq(borrowed_ptr, owned_ptr));
+
+            match owned.value.parts[0].kind {
+                ValueKind::Text(ref text) => {
+                    assert!(text.as_borrowed_str().is_none());
+                    assert_eq!("abc", text.as_str());
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        #[test]
+        fn collect_owned() {
+            let short_lived = String::from("abc");
+
+            let buf = ValueBuf::collect_owned(&short_lived).unwrap();
+            drop(short_lived);
+
+            match buf.value.parts[0].kind {
+                ValueKind::Text(ref text) => {
+                    assert!(text.as_borrowed_str().is_none());
+                    assert_eq!("abc", text.as_str());
+                }
+                _ => unreachable!(),
+            }
         }
     }
 }

--- a/src/data/text.rs
+++ b/src/data/text.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /**
-Stream a [`fmt::Display`] into an [`sval::Stream`].
+Stream a [`fmt::Display`] into a [`Stream`].
 */
 pub fn stream_display<'sval>(
     stream: &mut (impl Stream<'sval> + ?Sized),


### PR DESCRIPTION
This PR makes it possible to take a buffered value and ensure it doesn't contain any borrowed strings or slices internally. It does this as efficiently as possible; re-using the internal value buffer and not touching values that don't borrow.

It also adds `collect_owned` methods to `Value` and `ValueBuf`, so you can build a fully owned value that way too.