### PR TITLE
Don't panic when formatting ToFmt

### DIFF
--- a/fmt/src/to_fmt.rs
+++ b/fmt/src/to_fmt.rs
@@ -36,12 +36,18 @@ pub fn stream_to_fmt(fmt: &mut fmt::Formatter, v: impl sval::Value) -> fmt::Resu
 
 impl<V: sval::Value> fmt::Debug for ToFmt<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        stream_to_fmt(f, &self.0)
+        fmt::Display::fmt(self, f)
     }
 }
 
 impl<V: sval::Value> fmt::Display for ToFmt<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        stream_to_fmt(f, &self.0)
+        // If the `Value` impl fails then swallow the error rather than
+        // propagate it; Traits like `ToString` expect formatting to be
+        // infallible unless the writer itself fails
+        match stream_to_fmt(f, &self.0) {
+            Ok(()) => Ok(()),
+            Err(e) => write!(f, "<{}>", e),
+        }
     }
 }

--- a/fmt/test/lib.rs
+++ b/fmt/test/lib.rs
@@ -219,3 +219,24 @@ fn debug_exotic_unnamed_enum() {
         format!("{:?}", sval_fmt::ToFmt::new(UntaggedEnum::I32(42)))
     );
 }
+
+#[test]
+    fn failing_value_does_not_panic_to_string() {
+    struct Kaboom;
+
+    impl sval::Value for Kaboom {
+        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, _: &mut S) -> sval::Result {
+            Err(sval::Error::new())
+        }
+    }
+
+    #[derive(Value)]
+        struct NestedKaboom {
+        a: i32,
+        b: Kaboom,
+        c: i32,
+    }
+
+    assert_eq!("<an error occurred when formatting an argument>", sval_fmt::ToFmt::new(Kaboom).to_string());
+    assert_eq!("NestedKaboom { a: 1, b: <an error occurred when formatting an argument>", sval_fmt::ToFmt::new(NestedKaboom { a: 1, b: Kaboom, c: 2 }).to_string());
+}


### PR DESCRIPTION
This is the same as https://github.com/KodrAus/serde_fmt/pull/15. If an implementation of `Value` panics (which they're allowed to do) then attempting to format it will panic. This works around that in the same way by printing the error within the formatted string without returning it.