### PR TITLE
Add Value::tag for determining the kind of a value

### DIFF
--- a/derive/src/value.rs
+++ b/derive/src/value.rs
@@ -88,6 +88,8 @@ fn derive_struct<'a>(
 
     let match_arm = stream_record(quote!(#ident), tag, &label, index, fields);
 
+    let tag = quote_tag_owned(tag);
+
     TokenStream::from(quote! {
         const _: () = {
             extern crate sval;
@@ -99,6 +101,10 @@ fn derive_struct<'a>(
                     }
 
                     Ok(())
+                }
+
+                fn tag(&self) -> Option<sval::Tag> {
+                    #tag
                 }
             }
         };
@@ -121,6 +127,8 @@ fn derive_unit_struct<'a>(
 
     let match_arm = stream_tag(quote!(_), tag, &label, index);
 
+    let tag = quote_tag_owned(tag);
+
     TokenStream::from(quote! {
         const _: () = {
             extern crate sval;
@@ -132,6 +140,10 @@ fn derive_unit_struct<'a>(
                     }
 
                     Ok(())
+                }
+
+                fn tag(&self) -> Option<sval::Tag> {
+                    #tag
                 }
             }
         };
@@ -157,6 +169,8 @@ fn derive_newtype<'a>(
 
     let match_arm = stream_newtype(quote!(#ident), tag, &label, index);
 
+    let tag = quote_tag_owned(tag);
+
     TokenStream::from(quote! {
         const _: () = {
             extern crate sval;
@@ -168,6 +182,10 @@ fn derive_newtype<'a>(
                     }
 
                     Ok(())
+                }
+
+                fn tag(&self) -> Option<sval::Tag> {
+                    #tag
                 }
             }
         };
@@ -191,6 +209,8 @@ fn derive_tuple<'a>(
 
     let match_arm = stream_tuple(quote!(#ident), tag, &label, index, fields);
 
+    let tag = quote_tag_owned(tag);
+
     TokenStream::from(quote! {
         const _: () = {
             extern crate sval;
@@ -202,6 +222,10 @@ fn derive_tuple<'a>(
                     }
 
                     Ok(())
+                }
+
+                fn tag(&self) -> Option<sval::Tag> {
+                    #tag
                 }
             }
         };
@@ -266,6 +290,8 @@ fn derive_enum<'a>(
         });
     }
 
+    let tag = quote_tag_owned(tag);
+
     TokenStream::from(quote! {
         const _: () = {
             extern crate sval;
@@ -279,6 +305,10 @@ fn derive_enum<'a>(
                     }
 
                     stream.enum_end(#enum_tag, #enum_label, #enum_index)
+                }
+
+                fn tag(&self) -> Option<sval::Tag> {
+                    #tag
                 }
             }
         };
@@ -448,6 +478,13 @@ fn quote_tag_label_index(
 fn quote_tag(tag: Option<&Path>) -> proc_macro2::TokenStream {
     match tag {
         Some(tag) => quote!(Some(&#tag)),
+        None => quote!(None),
+    }
+}
+
+fn quote_tag_owned(tag: Option<&Path>) -> proc_macro2::TokenStream {
+    match tag {
+        Some(tag) => quote!(Some(#tag)),
         None => quote!(None),
     }
 }

--- a/dynamic/src/value.rs
+++ b/dynamic/src/value.rs
@@ -5,6 +5,7 @@ mod private {
 
     pub trait DispatchValue {
         fn dispatch_stream<'sval>(&'sval self, stream: &mut dyn Stream<'sval>) -> sval::Result;
+        fn dispatch_tag(&self) -> Option<sval::Tag>;
         fn dispatch_to_bool(&self) -> Option<bool>;
         fn dispatch_to_f32(&self) -> Option<f32>;
         fn dispatch_to_f64(&self) -> Option<f64>;
@@ -43,6 +44,10 @@ impl<T: sval::Value> private::EraseValue for T {
 impl<T: sval::Value> private::DispatchValue for T {
     fn dispatch_stream<'sval>(&'sval self, stream: &mut dyn Stream<'sval>) -> sval::Result {
         self.stream(stream)
+    }
+
+    fn dispatch_tag(&self) -> Option<sval::Tag> {
+        self.tag()
     }
 
     fn dispatch_to_bool(&self) -> Option<bool> {
@@ -111,6 +116,10 @@ macro_rules! impl_value {
         $($impl)* {
             fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, mut stream: &mut S) -> sval::Result {
                 self.erase_value().0.dispatch_stream(&mut stream)
+            }
+
+            fn tag(&self) -> Option<sval::Tag> {
+                self.erase_value().0.dispatch_tag()
             }
 
             fn to_bool(&self) -> Option<bool> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -350,6 +350,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn unit_tag() {
+        assert_eq!(Some(tags::RUST_UNIT), ().tag());
+    }
+
+    #[test]
     fn label_send_sync() {
         fn assert<T: Send + Sync>() {}
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -289,6 +289,10 @@ impl Value for bool {
         stream.bool(*self)
     }
 
+    fn tag(&self) -> Option<Tag> {
+        None
+    }
+
     fn to_bool(&self) -> Option<bool> {
         Some(*self)
     }

--- a/src/data/number.rs
+++ b/src/data/number.rs
@@ -102,4 +102,34 @@ mod tests {
         assert_eq!(Some(3f32), 3f32.to_f32());
         assert_eq!(Some(4f64), 4f64.to_f64());
     }
+
+    #[test]
+    fn number_tag() {
+        struct Number(&'static str);
+
+        impl Value for Number {
+            fn stream<'sval, S: Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> Result {
+                stream.tagged_begin(Some(&tags::NUMBER), None, None)?;
+                stream.value(self.0)?;
+                stream.tagged_end(Some(&tags::NUMBER), None, None)
+            }
+        }
+
+        assert_eq!(Some(tags::NUMBER), 1u8.tag());
+        assert_eq!(Some(tags::NUMBER), 1u16.tag());
+        assert_eq!(Some(tags::NUMBER), 1u32.tag());
+        assert_eq!(Some(tags::NUMBER), 1u64.tag());
+        assert_eq!(Some(tags::NUMBER), 1u128.tag());
+
+        assert_eq!(Some(tags::NUMBER), 1i8.tag());
+        assert_eq!(Some(tags::NUMBER), 1i16.tag());
+        assert_eq!(Some(tags::NUMBER), 1i32.tag());
+        assert_eq!(Some(tags::NUMBER), 1i64.tag());
+        assert_eq!(Some(tags::NUMBER), 1i128.tag());
+
+        assert_eq!(Some(tags::NUMBER), 1f32.tag());
+        assert_eq!(Some(tags::NUMBER), 1f64.tag());
+
+        assert_eq!(Some(tags::NUMBER), Number("42").tag());
+    }
 }

--- a/src/data/option.rs
+++ b/src/data/option.rs
@@ -111,4 +111,10 @@ mod tests {
 
         assert_eq!(Some("a string"), Some("a string").to_text());
     }
+
+    #[test]
+    fn option_tag() {
+        assert_eq!(Some(tags::RUST_OPTION_SOME), Some(42).tag());
+        assert_eq!(Some(tags::RUST_OPTION_NONE), None::<i32>.tag());
+    }
 }

--- a/src/data/seq.rs
+++ b/src/data/seq.rs
@@ -235,3 +235,13 @@ mod alloc_support {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn array_tag() {
+        assert_eq!(Some(tags::CONSTANT_SIZE), [true, false].tag());
+    }
+}

--- a/src/data/text.rs
+++ b/src/data/text.rs
@@ -1,6 +1,6 @@
 use crate::{
     std::fmt::{self, Write as _},
-    Error, Result, Stream, Value,
+    Error, Result, Stream, Tag, Value,
 };
 
 /**
@@ -45,6 +45,10 @@ impl Value for str {
         stream.text_end()
     }
 
+    fn tag(&self) -> Option<Tag> {
+        None
+    }
+
     fn to_text(&self) -> Option<&str> {
         Some(self)
     }
@@ -59,6 +63,10 @@ mod alloc_support {
     impl Value for String {
         fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
             (&**self).stream(stream)
+        }
+
+        fn tag(&self) -> Option<Tag> {
+            None
         }
 
         #[inline]


### PR DESCRIPTION
This PR adds a convenient `Value::tag` method that can be used to return the tag of a value, if there is one. This can be useful for streams that want to dispatch based on the tag, before they've started to stream. As an example, I have a case where I have a value and a formatter. I want to know if the value I'm holding is a number before I apply the formatter to it and lose that information.

The utility of this method is somewhat limited by primitive types like booleans not having their own tags. We could introduce them if it's useful.