### PR TITLE
Add back license files to all published crates

### DIFF
--- a/buffer/LICENSE-APACHE
+++ b/buffer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/buffer/LICENSE-MIT
+++ b/buffer/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/derive/LICENSE-APACHE
+++ b/derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/derive/LICENSE-MIT
+++ b/derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/dynamic/LICENSE-APACHE
+++ b/dynamic/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/dynamic/LICENSE-MIT
+++ b/dynamic/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fmt/LICENSE-APACHE
+++ b/fmt/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fmt/LICENSE-MIT
+++ b/fmt/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/json/LICENSE-APACHE
+++ b/json/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/json/LICENSE-MIT
+++ b/json/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/ref/LICENSE-APACHE
+++ b/ref/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/ref/LICENSE-MIT
+++ b/ref/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/serde/LICENSE-APACHE
+++ b/serde/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/serde/LICENSE-MIT
+++ b/serde/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/test/LICENSE-APACHE
+++ b/test/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/test/LICENSE-MIT
+++ b/test/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
It looks like with "the big rewrite" between 1.0.0-alpha.5 and 2.0.0 (https://github.com/sval-rs/sval/pull/117) some things that were previously there were dropped and / or accidentally reverted (including my previous PR, https://github.com/sval-rs/sval/pull/108).

This PR should reintroduce license files to all published crates (which is one of the conditions of both the Apache-2.0 and MIT licenses).