### PR TITLE
Support negative index values

### DIFF
--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -1,4 +1,4 @@
-use syn::{spanned::Spanned, Attribute, Lit, LitBool, Path};
+use syn::{spanned::Spanned, Attribute, Expr, Lit, LitBool, Path};
 
 /**
 Get an attribute that is applicable to a container.
@@ -151,6 +151,14 @@ pub(crate) trait RawAttribute {
 
 pub(crate) trait SvalAttribute: RawAttribute {
     type Result: 'static;
+
+    fn from_expr(&self, expr: &Expr) -> Option<Self::Result> {
+        if let Expr::Lit(lit) = expr {
+            Some(self.from_lit(&lit.lit))
+        } else {
+            None
+        }
+    }
 
     fn from_lit(&self, lit: &Lit) -> Self::Result;
 }

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -102,7 +102,7 @@ to use for the annotated item.
 pub(crate) struct Index;
 
 impl SvalAttribute for Index {
-    type Result = usize;
+    type Result = isize;
 
     fn from_lit(&self, lit: &Lit) -> Self::Result {
         if let Lit::Int(ref n) = lit {

--- a/derive/src/value.rs
+++ b/derive/src/value.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use crate::attr::SvalAttribute;
 use crate::{attr, bound};
 use proc_macro::TokenStream;
 use syn::{
@@ -259,7 +260,15 @@ fn derive_enum<'a>(
         let label = attr::container(attr::Label, &variant.attrs)
             .unwrap_or_else(|| variant.ident.to_string());
 
-        let index = index_allocator.next_index(attr::container(attr::Index, &variant.attrs));
+        // If there's a discrimant, use it as the index
+        let index = index_allocator.next_index(
+            attr::container(attr::Index, &variant.attrs).or_else(|| {
+                variant
+                    .discriminant
+                    .as_ref()
+                    .and_then(|(_, discriminant)| attr::Index.from_expr(discriminant))
+            }),
+        );
 
         let variant_ident = &variant.ident;
 

--- a/derive/src/value.rs
+++ b/derive/src/value.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
-use crate::attr::SvalAttribute;
-use crate::{attr, bound};
+use crate::{attr::{self, SvalAttribute}, bound};
 use proc_macro::TokenStream;
 use syn::{
     spanned::Spanned, Data, DataEnum, DataStruct, DeriveInput, Field, Fields, FieldsNamed,

--- a/derive/src/value.rs
+++ b/derive/src/value.rs
@@ -536,9 +536,9 @@ fn quote_optional_label(label: Option<&str>) -> proc_macro2::TokenStream {
 
 fn quote_index(index: Index) -> proc_macro2::TokenStream {
     match index {
-        Index::Explicit(index) => quote!(&sval::Index::new(#index)),
+        Index::Explicit(index) => quote!(&sval::Index::from(#index)),
         Index::Implicit(index) => {
-            quote!(&sval::Index::new(#index).with_tag(&sval::tags::VALUE_OFFSET))
+            quote!(&sval::Index::from(#index).with_tag(&sval::tags::VALUE_OFFSET))
         }
     }
 }
@@ -554,7 +554,7 @@ fn quote_optional_index(index: Option<Index>) -> proc_macro2::TokenStream {
 }
 
 struct IndexAllocator {
-    next_index: usize,
+    next_index: isize,
     explicit: bool,
 }
 
@@ -566,11 +566,11 @@ impl IndexAllocator {
         }
     }
 
-    fn index_of(explicit: Option<usize>) -> Option<Index> {
+    fn index_of(explicit: Option<isize>) -> Option<Index> {
         explicit.map(Index::Explicit)
     }
 
-    fn next_index(&mut self, explicit: Option<usize>) -> Index {
+    fn next_index(&mut self, explicit: Option<isize>) -> Index {
         if let Some(index) = explicit {
             self.explicit = true;
             self.next_index = index + 1;
@@ -591,6 +591,6 @@ impl IndexAllocator {
 
 #[derive(Debug, Clone, Copy)]
 enum Index {
-    Implicit(usize),
-    Explicit(usize),
+    Implicit(isize),
+    Explicit(isize),
 }

--- a/derive/src/value.rs
+++ b/derive/src/value.rs
@@ -260,7 +260,7 @@ fn derive_enum<'a>(
         let label = attr::container(attr::Label, &variant.attrs)
             .unwrap_or_else(|| variant.ident.to_string());
 
-        // If there's a discrimant, use it as the index
+        // If there's a discriminant, use it as the index
         let index = index_allocator.next_index(
             attr::container(attr::Index, &variant.attrs).or_else(|| {
                 variant

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -611,8 +611,8 @@ mod derive_enum {
         #[derive(Value)]
         #[repr(i32)]
         enum Enum {
-            A = 3,
-            #[sval(index = 2)]
+            A = -3,
+            #[sval(index = -2)]
             B = 4,
             C(i32) = -1,
         }
@@ -625,7 +625,7 @@ mod derive_enum {
                 Tag(
                     None,
                     Some(sval::Label::new("A")),
-                    Some(sval::Index::new_i32(3)),
+                    Some(sval::Index::new_i32(-3)),
                 ),
                 EnumEnd(None, Some(sval::Label::new("Enum")), None),
             ]
@@ -639,7 +639,7 @@ mod derive_enum {
                 Tag(
                     None,
                     Some(sval::Label::new("B")),
-                    Some(sval::Index::new_i32(2)),
+                    Some(sval::Index::new_i32(-2)),
                 ),
                 EnumEnd(None, Some(sval::Label::new("Enum")), None),
             ]
@@ -653,13 +653,13 @@ mod derive_enum {
                 TaggedBegin(
                     None,
                     Some(sval::Label::new("C")),
-                    Some(sval::Index::new_i32(3)),
+                    Some(sval::Index::new_i32(-1)),
                 ),
                 I32(42),
                 TaggedEnd(
                     None,
                     Some(sval::Label::new("C")),
-                    Some(sval::Index::new_i32(3)),
+                    Some(sval::Index::new_i32(-1)),
                 ),
                 EnumEnd(None, Some(sval::Label::new("Enum")), None),
             ]

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -414,16 +414,16 @@ mod derive_enum {
         #[derive(Value)]
         #[sval(tag = "CONTAINER", label = "enum", index = 0)]
         enum Enum {
-            #[sval(tag = "VARIANT", label = "tag", index = 1)]
+            #[sval(tag = "VARIANT", label = "tag", index = -1)]
             Tag,
-            #[sval(tag = "VARIANT", label = "tagged", index = 2)]
+            #[sval(tag = "VARIANT", label = "tagged", index = -2)]
             Tagged(i32),
-            #[sval(tag = "VARIANT", label = "record", index = 3)]
+            #[sval(tag = "VARIANT", label = "record", index = -3)]
             Record {
                 #[sval(tag = "FIELD", label = "field")]
                 a: i32,
             },
-            #[sval(tag = "VARIANT", label = "tuple", index = 4)]
+            #[sval(tag = "VARIANT", label = "tuple", index = -4)]
             Tuple(
                 #[sval(tag = "FIELD", index = 1)] i32,
                 #[sval(tag = "FIELD", index = 2)] i32,
@@ -442,7 +442,7 @@ mod derive_enum {
                 Tag(
                     Some(VARIANT),
                     Some(sval::Label::new("tag")),
-                    Some(sval::Index::new(1)),
+                    Some(sval::Index::new_isize(-1)),
                 ),
                 EnumEnd(
                     Some(CONTAINER),
@@ -464,13 +464,13 @@ mod derive_enum {
                 TaggedBegin(
                     Some(VARIANT),
                     Some(sval::Label::new("tagged")),
-                    Some(sval::Index::new(2)),
+                    Some(sval::Index::new_isize(-2)),
                 ),
                 I32(42),
                 TaggedEnd(
                     Some(VARIANT),
                     Some(sval::Label::new("tagged")),
-                    Some(sval::Index::new(2)),
+                    Some(sval::Index::new_isize(-2)),
                 ),
                 EnumEnd(
                     Some(CONTAINER),
@@ -492,7 +492,7 @@ mod derive_enum {
                 RecordTupleBegin(
                     Some(VARIANT),
                     Some(sval::Label::new("record")),
-                    Some(sval::Index::new(3)),
+                    Some(sval::Index::new_isize(-3)),
                     Some(1),
                 ),
                 RecordTupleValueBegin(Some(FIELD), sval::Label::new("field"), sval::Index::new(0)),
@@ -501,7 +501,7 @@ mod derive_enum {
                 RecordTupleEnd(
                     Some(VARIANT),
                     Some(sval::Label::new("record")),
-                    Some(sval::Index::new(3)),
+                    Some(sval::Index::new_isize(-3)),
                 ),
                 EnumEnd(
                     Some(CONTAINER),
@@ -523,7 +523,7 @@ mod derive_enum {
                 TupleBegin(
                     Some(VARIANT),
                     Some(sval::Label::new("tuple")),
-                    Some(sval::Index::new(4)),
+                    Some(sval::Index::new_isize(-4)),
                     Some(2),
                 ),
                 TupleValueBegin(Some(FIELD), sval::Index::new(1)),
@@ -535,7 +535,7 @@ mod derive_enum {
                 TupleEnd(
                     Some(VARIANT),
                     Some(sval::Label::new("tuple")),
-                    Some(sval::Index::new(4)),
+                    Some(sval::Index::new_isize(-4)),
                 ),
                 EnumEnd(
                     Some(CONTAINER),

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -607,6 +607,66 @@ mod derive_enum {
     }
 
     #[test]
+    fn discriminant() {
+        #[derive(Value)]
+        #[repr(i32)]
+        enum Enum {
+            A = 3,
+            #[sval(index = 2)]
+            B = 4,
+            C(i32) = -1,
+        }
+
+        assert_tokens(&Enum::A, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                Tag(
+                    None,
+                    Some(sval::Label::new("A")),
+                    Some(sval::Index::new_i32(3)),
+                ),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::B, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                Tag(
+                    None,
+                    Some(sval::Label::new("B")),
+                    Some(sval::Index::new_i32(2)),
+                ),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::C(42), {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                TaggedBegin(
+                    None,
+                    Some(sval::Label::new("C")),
+                    Some(sval::Index::new_i32(3)),
+                ),
+                I32(42),
+                TaggedEnd(
+                    None,
+                    Some(sval::Label::new("C")),
+                    Some(sval::Index::new_i32(3)),
+                ),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+    }
+
+    #[test]
     fn empty() {
         #![allow(dead_code)]
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -246,21 +246,85 @@ impl fmt::Debug for Tag {
 The index of a value in its parent context.
 */
 #[derive(Clone)]
-pub struct Index(usize, Option<Tag>);
+pub struct Index(i128, Option<Tag>);
+
+impl From<i32> for Index {
+    fn from(index: i32) -> Self {
+        Index::new_i32(index)
+    }
+}
+
+impl From<i64> for Index {
+    fn from(index: i64) -> Self {
+        Index::new_i64(index)
+    }
+}
+
+impl From<isize> for Index {
+    fn from(index: isize) -> Self {
+        Index::new_isize(index)
+    }
+}
+
+impl From<u32> for Index {
+    fn from(index: u32) -> Self {
+        Index::new_u32(index)
+    }
+}
+
+impl From<u64> for Index {
+    fn from(index: u64) -> Self {
+        Index::new_u64(index)
+    }
+}
+
+impl From<usize> for Index {
+    fn from(index: usize) -> Self {
+        Index::new(index)
+    }
+}
 
 impl Index {
     /**
     Create a new index from a numeric value.
     */
     pub const fn new(index: usize) -> Self {
-        Index(index, None)
+        Index(index as i128, None)
     }
 
     /**
     Create a new None index from a 32bit numeric value.
     */
     pub const fn new_u32(index: u32) -> Self {
-        Index(index as usize, None)
+        Index(index as i128, None)
+    }
+
+    /**
+    Create a new None index from a 64bit numeric value.
+     */
+    pub const fn new_u64(index: u64) -> Self {
+        Index(index as i128, None)
+    }
+
+    /**
+    Create a new None index from a signed 32bit numeric value.
+     */
+    pub const fn new_i32(index: i32) -> Self {
+        Index(index as i128, None)
+    }
+
+    /**
+    Create a new None index from a signed 64bit numeric value.
+     */
+    pub const fn new_i64(index: i64) -> Self {
+        Index(index as i128, None)
+    }
+
+    /**
+    Create a new None index from a signed numeric value.
+     */
+    pub const fn new_isize(index: isize) -> Self {
+        Index(index as i128, None)
     }
 
     /**
@@ -277,14 +341,18 @@ impl Index {
     Try get the index as a numeric value.
     */
     pub const fn to_usize(&self) -> Option<usize> {
-        Some(self.0)
+        if self.0 >= usize::MIN as i128 && self.0 <= usize::MAX as i128 {
+            Some(self.0 as usize)
+        } else {
+            None
+        }
     }
 
     /**
     Try get the index as a 32-bit numeric value.
     */
     pub const fn to_u32(&self) -> Option<u32> {
-        if self.0 <= u32::MAX as usize {
+        if self.0 >= u32::MIN as i128 && self.0 <= u32::MAX as i128 {
             Some(self.0 as u32)
         } else {
             None
@@ -292,11 +360,44 @@ impl Index {
     }
 
     /**
-      Try get the index as a 64-bit numeric value.
+    Try get the index as a 64-bit numeric value.
     */
     pub const fn to_u64(&self) -> Option<u64> {
-        if self.0 <= u64::MAX as usize {
+        if self.0 >= u64::MIN as i128 && self.0 <= u64::MAX as i128 {
             Some(self.0 as u64)
+        } else {
+            None
+        }
+    }
+
+    /**
+    Try get the index as a signed numeric value.
+     */
+    pub const fn to_isize(&self) -> Option<isize> {
+        if self.0 >= isize::MIN as i128 && self.0 <= isize::MAX as i128 {
+            Some(self.0 as isize)
+        } else {
+            None
+        }
+    }
+
+    /**
+    Try get the index as a signed 32-bit numeric value.
+     */
+    pub const fn to_i32(&self) -> Option<i32> {
+        if self.0 >= i32::MIN as i128 && self.0 <= i32::MAX as i128 {
+            Some(self.0 as i32)
+        } else {
+            None
+        }
+    }
+
+    /**
+    Try get the index as a signed 64-bit numeric value.
+     */
+    pub const fn to_i64(&self) -> Option<i64> {
+        if self.0 >= i64::MIN as i128 && self.0 <= i64::MAX as i128 {
+            Some(self.0 as i64)
         } else {
             None
         }
@@ -470,15 +571,38 @@ mod tests {
     }
 
     #[test]
-    fn index() {
-        let small = Index::new(1);
-        let large = Index::new(usize::MAX);
+    fn index_convert() {
+        for (index, to_i32, to_i64, to_u32, to_u64) in [
+            (
+                Index::from(0),
+                Some(0i32),
+                Some(0i64),
+                Some(0u32),
+                Some(0u64),
+            ),
+            (
+                Index::from(i32::MIN),
+                Some(i32::MIN),
+                Some(i32::MIN as i64),
+                None,
+                None,
+            ),
+            (Index::from(i64::MIN), None, Some(i64::MIN), None, None),
+            (
+                Index::from(u32::MAX),
+                None,
+                Some(u32::MAX as i64),
+                Some(u32::MAX),
+                Some(u32::MAX as u64),
+            ),
+            (Index::from(u64::MAX), None, None, None, Some(u64::MAX)),
+        ] {
+            assert_eq!(to_i32, index.to_i32(), "{:?}", index);
+            assert_eq!(to_i64, index.to_i64(), "{:?}", index);
 
-        if usize::MAX > (u32::MAX as usize) {
-            assert!(large.to_u32().is_none());
+            assert_eq!(to_u32, index.to_u32(), "{:?}", index);
+            assert_eq!(to_u64, index.to_u64(), "{:?}", index);
         }
-
-        assert_eq!(1, small.to_u32().unwrap());
     }
 
     #[test]

--- a/src/data/tags.rs
+++ b/src/data/tags.rs
@@ -75,7 +75,7 @@ Any datatype that accepts a size hint.
 pub const CONSTANT_SIZE: Tag = Tag::new("CONSTANT_SIZE");
 
 /**
-A tag for indexes that are zero-based offsets into a larger structure.
+A tag for indexes that are zero-based non-negative offsets into a larger structure.
 
 `sval` uses this tag by default for indexes on tuple values and enum variants.
 */


### PR DESCRIPTION
This PR supports creating `Index`es with negative values. We store the index value as an `i128`, but only exposes up to 64bit values so we can fit both signed and unsigned variants without truncation.