### PR TITLE
Add support for wrapping value data in tags

### DIFF
--- a/derive/test/compile_fail/newtype_data_tag.rs
+++ b/derive/test/compile_fail/newtype_data_tag.rs
@@ -1,0 +1,8 @@
+use sval_derive::*;
+
+#[derive(Value)]
+pub struct Newtype(#[sval(data_tag = "sval::tags::NUMBER")] i32);
+
+fn main() {
+
+}

--- a/derive/test/compile_fail/newtype_data_tag.stderr
+++ b/derive/test/compile_fail/newtype_data_tag.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> compile_fail/newtype_data_tag.rs:3:10
+  |
+3 | #[derive(Value)]
+  |          ^^^^^
+  |
+  = help: message: unsupported attribute `data_tag` on newtype field

--- a/derive/test/compile_fail/newtype_index.rs
+++ b/derive/test/compile_fail/newtype_index.rs
@@ -1,0 +1,8 @@
+use sval_derive::*;
+
+#[derive(Value)]
+pub struct Newtype(#[sval(index = 1)] i32);
+
+fn main() {
+
+}

--- a/derive/test/compile_fail/newtype_index.stderr
+++ b/derive/test/compile_fail/newtype_index.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> compile_fail/newtype_index.rs:3:10
+  |
+3 | #[derive(Value)]
+  |          ^^^^^
+  |
+  = help: message: unsupported attribute `index` on newtype field

--- a/derive/test/compile_fail/newtype_label.rs
+++ b/derive/test/compile_fail/newtype_label.rs
@@ -1,0 +1,8 @@
+use sval_derive::*;
+
+#[derive(Value)]
+pub struct Newtype(#[sval(label = "value")] i32);
+
+fn main() {
+
+}

--- a/derive/test/compile_fail/newtype_label.stderr
+++ b/derive/test/compile_fail/newtype_label.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> compile_fail/newtype_label.rs:3:10
+  |
+3 | #[derive(Value)]
+  |          ^^^^^
+  |
+  = help: message: unsupported attribute `label` on newtype field

--- a/derive/test/compile_fail/newtype_tag.rs
+++ b/derive/test/compile_fail/newtype_tag.rs
@@ -1,0 +1,8 @@
+use sval_derive::*;
+
+#[derive(Value)]
+pub struct Newtype(#[sval(tag = "sval::tags::NUMBER")] i32);
+
+fn main() {
+
+}

--- a/derive/test/compile_fail/newtype_tag.stderr
+++ b/derive/test/compile_fail/newtype_tag.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> compile_fail/newtype_tag.rs:3:10
+  |
+3 | #[derive(Value)]
+  |          ^^^^^
+  |
+  = help: message: unsupported attribute `tag` on newtype field

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -117,6 +117,55 @@ mod derive_struct {
     }
 
     #[test]
+    fn data_tagged() {
+        #[derive(Value)]
+        struct RecordTuple {
+            #[sval(data_tag = "sval::tags::NUMBER")]
+            a: i32,
+        }
+
+        assert_tokens(&RecordTuple { a: 42 }, {
+            use sval_test::Token::*;
+
+            &[
+                RecordTupleBegin(None, Some(sval::Label::new("RecordTuple")), None, Some(1)),
+                RecordTupleValueBegin(None, sval::Label::new("a"), sval::Index::new(0)),
+                TaggedBegin(Some(sval::tags::NUMBER), None, None),
+                I32(42),
+                TaggedEnd(Some(sval::tags::NUMBER), None, None),
+                RecordTupleValueEnd(None, sval::Label::new("a"), sval::Index::new(0)),
+                RecordTupleEnd(None, Some(sval::Label::new("RecordTuple")), None),
+            ]
+        })
+    }
+
+    #[test]
+    fn unlabeled_unindexed_data_tagged() {
+        #[derive(Value)]
+        #[sval(unlabeled_values, unindexed_values)]
+        struct Seq {
+            #[sval(data_tag = "sval::tags::NUMBER")]
+            a: i32,
+        }
+
+        assert_tokens(&Seq { a: 42 }, {
+            use sval_test::Token::*;
+
+            &[
+                TaggedBegin(None, Some(sval::Label::new("Seq")), None),
+                SeqBegin(Some(1)),
+                SeqValueBegin,
+                TaggedBegin(Some(sval::tags::NUMBER), None, None),
+                I32(42),
+                TaggedEnd(Some(sval::tags::NUMBER), None, None),
+                SeqValueEnd,
+                SeqEnd,
+                TaggedEnd(None, Some(sval::Label::new("Seq")), None),
+            ]
+        })
+    }
+
+    #[test]
     fn flattened() {
         #[derive(Value)]
         struct Inner {

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -29,6 +29,32 @@ impl RawAttribute for TagAttr {
 }
 
 /**
+The `data_tag` attribute.
+
+This attribute specifies a path to an `sval::Tag` to use
+for the data of the annotated item.
+ */
+pub(crate) struct DataTagAttr;
+
+impl SvalAttribute for DataTagAttr {
+    type Result = syn::Path;
+
+    fn from_lit(&self, lit: &Lit) -> Self::Result {
+        if let Lit::Str(ref s) = lit {
+            s.parse().expect("invalid value")
+        } else {
+            panic!("unexpected value")
+        }
+    }
+}
+
+impl RawAttribute for DataTagAttr {
+    fn key(&self) -> &str {
+        "data_tag"
+    }
+}
+
+/**
 The `label` attribute.
 
 This attribute specifies an `sval::Label` as a constant

--- a/json/test/lib.rs
+++ b/json/test/lib.rs
@@ -106,6 +106,28 @@ fn stream_native_text() {
 }
 
 #[test]
+fn stream_native_text_nested() {
+    #[derive(Value)]
+    struct MapStruct<'a> {
+        #[sval(data_tag = "sval_json::tags::JSON_TEXT")]
+        text: &'a str,
+    }
+
+    assert_stream("{\"text\":\"a\nb\"}", MapStruct { text: "a\nb" });
+}
+
+#[test]
+fn stream_native_number_nested() {
+    #[derive(Value)]
+    struct MapStruct<'a> {
+        #[sval(data_tag = "sval_json::tags::JSON_NUMBER")]
+        number: &'a str,
+    }
+
+    assert_stream("{\"number\":123.456}", MapStruct { number: "123.456" });
+}
+
+#[test]
 fn stream_option() {
     assert_json(Some(42i32));
     assert_json(None::<i32>);


### PR DESCRIPTION
This PR adds support for wrapping data in records and tuples in tags so you don't need to wrap them in newtypes and tag those.