### PR TITLE
Rename some unstable attributes and document sval_derive

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -21,5 +21,6 @@ version = "2.6.1"
 path = "../derive_macros"
 
 [dependencies.sval_flatten]
+version = "2.6.1"
 path = "../flatten"
 optional = true

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,3 +1,55 @@
+/*!
+`#![derive(Value)]`.
+
+This library hosts a custom-derive to simplify implementing `sval::Value`.
+
+# Structs
+
+Container attributes:
+
+- `#[sval(tag = "path::to::TAG")]`: Set a tag on the struct. No tag is used by default.
+- `#[sval(label = "text")]`: Set a label on the struct. The identifier of the struct is used by default.
+- `#[sval(index = 1)]`: Set an index on the struct. No index is used by default.
+- `#[sval(unlabeled_fields)]`: Specify that all fields should be unlabeled. This will stream the struct as a tuple.
+If `#[sval(unindexed_fields)]` is also specified then it will stream the struct as a sequence.
+- `#[sval(unindexed_fields]`: Specify that all fields should be unindexed. This will stream the struct as a record.
+If `#[sval(unlabeled_fields)]` is also specified then it will stream the struct as a sequence.
+
+Field attributes:
+
+- `#[sval(tag = "path::to::TAG")]`: Set a tag on the struct field itself. No tag is used by default.
+If you want to use a tag to signal that the field's value has a particular property then use `#[sval(data_tag)]`.
+- `#[sval(data_tag = "path::to::TAG")]`: Set a tag on the struct field's value. No tag is used by default.
+- `#[sval(label = "text")]`: Set a label on the struct field. The identifier of the field is used by default.
+- `#[sval(index = 1)]`: Set an index on the struct field. The zero-based offset of the field is used by default.
+- `#[sval(skip)]`: Skip a field.
+- `#[sval(flatten)]`: Flatten the field onto the struct. This attribute requires the `flatten` Cargo feature.
+
+# Newtypes
+
+Container attributes:
+
+- `#[sval(tag = "path::to::TAG")]`: Set a tag on the newtype. No tag is used by default.
+- `#[sval(label = "text")]`: Set a label on the newtype. The identifier of the newtype is used by default.
+- `#[sval(index = 1)]`: Set an index on the newtype. No index is used by default.
+- `#[sval(transparent)]`: Stream the newtype as its underlying field without wrapping it.
+
+# Enums
+
+Container attributes:
+
+- `#[sval(tag = "path::to::TAG")]`: Set a tag on the enum. No tag is used by default.
+- `#[sval(label = "text")]`: Set a label on the enum. The identifier of the enum is used by default.
+- `#[sval(index = 1)]`: Set an index on the enum. No index is used by default.
+- `#[sval(dynamic)]`: Stream the variant without wrapping it in an enum.
+
+Variant attributes:
+
+- `#[sval(tag = "path::to::TAG")]`: Set a tag on the enum variant itself. No tag is used by default.
+- `#[sval(label = "text")]`: Set a label on the enum variant. The identifier of the variant is used by default.
+- `#[sval(index = 1)]`: Set an index on the enum variant. The zero-based offset of the variant is used by default.
+*/
+
 #[doc(inline)]
 pub use sval_derive_macros::*;
 

--- a/derive/test/compile_fail/enum_unindexed_fields.rs
+++ b/derive/test/compile_fail/enum_unindexed_fields.rs
@@ -1,7 +1,7 @@
 use sval_derive::*;
 
 #[derive(Value)]
-#[sval(unindexed_values)]
+#[sval(unindexed_fields)]
 pub enum Enum {
     A,
     B,

--- a/derive/test/compile_fail/enum_unindexed_fields.stderr
+++ b/derive/test/compile_fail/enum_unindexed_fields.stderr
@@ -4,4 +4,4 @@ error: proc-macro derive panicked
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: unsupported attribute `unindexed_values` on enum
+  = help: message: unsupported attribute `unindexed_fields` on enum

--- a/derive/test/compile_fail/enum_unlabeled_fields.rs
+++ b/derive/test/compile_fail/enum_unlabeled_fields.rs
@@ -1,7 +1,7 @@
 use sval_derive::*;
 
 #[derive(Value)]
-#[sval(unlabeled_values)]
+#[sval(unlabeled_fields)]
 pub enum Enum {
     A,
     B,

--- a/derive/test/compile_fail/enum_unlabeled_fields.stderr
+++ b/derive/test/compile_fail/enum_unlabeled_fields.stderr
@@ -4,4 +4,4 @@ error: proc-macro derive panicked
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: unsupported attribute `unlabeled_values` on enum
+  = help: message: unsupported attribute `unlabeled_fields` on enum

--- a/derive/test/compile_fail/record_as_seq_incomplete_indexes.rs
+++ b/derive/test/compile_fail/record_as_seq_incomplete_indexes.rs
@@ -1,7 +1,7 @@
 use sval_derive::*;
 
 #[derive(Value)]
-#[sval(unindexed_values, unlabeled_values)]
+#[sval(unindexed_fields, unlabeled_fields)]
 pub struct Record {
     #[sval(index = 1)]
     a: i32,

--- a/derive/test/compile_fail/record_as_seq_incomplete_labels.rs
+++ b/derive/test/compile_fail/record_as_seq_incomplete_labels.rs
@@ -1,7 +1,7 @@
 use sval_derive::*;
 
 #[derive(Value)]
-#[sval(unindexed_values, unlabeled_values)]
+#[sval(unindexed_fields, unlabeled_fields)]
 pub struct Record {
     #[sval(label = "a")]
     a: i32,

--- a/derive/test/compile_fail/record_as_tuple_incomplete_labels.rs
+++ b/derive/test/compile_fail/record_as_tuple_incomplete_labels.rs
@@ -1,7 +1,7 @@
 use sval_derive::*;
 
 #[derive(Value)]
-#[sval(unlabeled_values)]
+#[sval(unlabeled_fields)]
 pub struct Record {
     #[sval(label = "a")]
     a: i32,

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -54,7 +54,7 @@ mod derive_struct {
     #[test]
     fn unlabeled() {
         #[derive(Value)]
-        #[sval(unlabeled_values)]
+        #[sval(unlabeled_fields)]
         struct Tuple {
             a: i32,
         }
@@ -75,7 +75,7 @@ mod derive_struct {
     #[test]
     fn unindexed() {
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Record {
             a: i32,
         }
@@ -96,7 +96,7 @@ mod derive_struct {
     #[test]
     fn unlabeled_unindexed() {
         #[derive(Value)]
-        #[sval(unlabeled_values, unindexed_values)]
+        #[sval(unlabeled_fields, unindexed_fields)]
         struct Seq {
             a: i32,
         }
@@ -142,7 +142,7 @@ mod derive_struct {
     #[test]
     fn unlabeled_unindexed_data_tagged() {
         #[derive(Value)]
-        #[sval(unlabeled_values, unindexed_values)]
+        #[sval(unlabeled_fields, unindexed_fields)]
         struct Seq {
             #[sval(data_tag = "sval::tags::NUMBER")]
             a: i32,
@@ -352,7 +352,7 @@ mod derive_tuple {
     #[test]
     fn unindexed() {
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Seq(i32, i32);
 
         assert_tokens(&Seq(42, 43), {
@@ -406,11 +406,11 @@ mod derive_tuple {
     #[test]
     fn unindexed_flattened() {
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Inner(i32, i32);
 
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Seq(i32, #[sval(flatten)] Inner, i32);
 
         assert_tokens(&Seq(1, Inner(2, 3), 4), {

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -172,7 +172,7 @@ impl SvalAttribute for UnlabeledValuesAttr {
 
 impl RawAttribute for UnlabeledValuesAttr {
     fn key(&self) -> &str {
-        "unlabeled_values"
+        "unlabeled_fields"
     }
 }
 
@@ -197,7 +197,7 @@ impl SvalAttribute for UnindexedValuesAttr {
 
 impl RawAttribute for UnindexedValuesAttr {
     fn key(&self) -> &str {
-        "unindexed_values"
+        "unindexed_fields"
     }
 }
 

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -152,13 +152,13 @@ impl RawAttribute for SkipAttr {
 }
 
 /**
-The `unlabeled` attribute.
+The `unlabeled_fields` attribute.
 
-This attribute signals that an item should be unlabeled.
+This attribute signals that all fields should be unlabeled.
 */
-pub(crate) struct UnlabeledValuesAttr;
+pub(crate) struct UnlabeledFieldsAttr;
 
-impl SvalAttribute for UnlabeledValuesAttr {
+impl SvalAttribute for UnlabeledFieldsAttr {
     type Result = bool;
 
     fn from_lit(&self, lit: &Lit) -> Self::Result {
@@ -170,20 +170,20 @@ impl SvalAttribute for UnlabeledValuesAttr {
     }
 }
 
-impl RawAttribute for UnlabeledValuesAttr {
+impl RawAttribute for UnlabeledFieldsAttr {
     fn key(&self) -> &str {
         "unlabeled_fields"
     }
 }
 
 /**
-The `unindexed` attribute.
+The `unindexed_fields` attribute.
 
-This attribute signals that an item should be unindexed.
+This attribute signals that all fields should be unindexed.
 */
-pub(crate) struct UnindexedValuesAttr;
+pub(crate) struct UnindexedFieldsAttr;
 
-impl SvalAttribute for UnindexedValuesAttr {
+impl SvalAttribute for UnindexedFieldsAttr {
     type Result = bool;
 
     fn from_lit(&self, lit: &Lit) -> Self::Result {
@@ -195,7 +195,7 @@ impl SvalAttribute for UnindexedValuesAttr {
     }
 }
 
-impl RawAttribute for UnindexedValuesAttr {
+impl RawAttribute for UnindexedFieldsAttr {
     fn key(&self) -> &str {
         "unindexed_fields"
     }

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -156,8 +156,8 @@ pub(crate) fn derive_enum<'a>(
                     attrs.tag(),
                     variant_label(attrs.label(), variant_ident),
                     variant_index(attrs.index(), discriminant),
-                    attrs.unlabeled_values(),
-                    attrs.unindexed_values(),
+                    attrs.unlabeled_fields(),
+                    attrs.unindexed_fields(),
                 )
             }
             Fields::Unnamed(ref fields) => {
@@ -170,8 +170,8 @@ pub(crate) fn derive_enum<'a>(
                     attrs.tag(),
                     variant_label(attrs.label(), variant_ident),
                     variant_index(attrs.index(), discriminant),
-                    attrs.unlabeled_values(),
-                    attrs.unindexed_values(),
+                    attrs.unlabeled_fields(),
+                    attrs.unindexed_fields(),
                 )
             }
         });

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -110,8 +110,8 @@ pub(crate) fn derive_enum<'a>(
                 &attr::TagAttr,
                 &attr::LabelAttr,
                 &attr::IndexAttr,
-                &attr::UnlabeledValuesAttr,
-                &attr::UnindexedValuesAttr,
+                &attr::UnlabeledFieldsAttr,
+                &attr::UnindexedFieldsAttr,
             ],
             &variant.attrs,
         );

--- a/derive_macros/src/derive/derive_struct.rs
+++ b/derive_macros/src/derive/derive_struct.rs
@@ -25,8 +25,8 @@ impl StructAttrs {
                 &attr::TagAttr,
                 &attr::LabelAttr,
                 &attr::IndexAttr,
-                &attr::UnlabeledValuesAttr,
-                &attr::UnindexedValuesAttr,
+                &attr::UnlabeledFieldsAttr,
+                &attr::UnindexedFieldsAttr,
             ],
             attrs,
         );
@@ -36,9 +36,9 @@ impl StructAttrs {
         let index = attr::get_unchecked("struct", attr::IndexAttr, attrs);
 
         let unlabeled_fields =
-            attr::get_unchecked("struct", attr::UnlabeledValuesAttr, attrs).unwrap_or(false);
+            attr::get_unchecked("struct", attr::UnlabeledFieldsAttr, attrs).unwrap_or(false);
         let unindexed_fields =
-            attr::get_unchecked("struct", attr::UnindexedValuesAttr, attrs).unwrap_or(false);
+            attr::get_unchecked("struct", attr::UnindexedFieldsAttr, attrs).unwrap_or(false);
 
         StructAttrs {
             tag,

--- a/derive_macros/src/derive/derive_struct.rs
+++ b/derive_macros/src/derive/derive_struct.rs
@@ -13,8 +13,8 @@ pub(crate) struct StructAttrs {
     tag: Option<Path>,
     label: Option<String>,
     index: Option<isize>,
-    unlabeled_values: bool,
-    unindexed_values: bool,
+    unlabeled_fields: bool,
+    unindexed_fields: bool,
 }
 
 impl StructAttrs {
@@ -35,17 +35,17 @@ impl StructAttrs {
         let label = attr::get_unchecked("struct", attr::LabelAttr, attrs);
         let index = attr::get_unchecked("struct", attr::IndexAttr, attrs);
 
-        let unlabeled_values =
+        let unlabeled_fields =
             attr::get_unchecked("struct", attr::UnlabeledValuesAttr, attrs).unwrap_or(false);
-        let unindexed_values =
+        let unindexed_fields =
             attr::get_unchecked("struct", attr::UnindexedValuesAttr, attrs).unwrap_or(false);
 
         StructAttrs {
             tag,
             label,
             index,
-            unlabeled_values,
-            unindexed_values,
+            unlabeled_fields,
+            unindexed_fields,
         }
     }
 
@@ -61,12 +61,12 @@ impl StructAttrs {
         self.index.map(IndexAllocator::const_index_of)
     }
 
-    pub(crate) fn unlabeled_values(&self) -> bool {
-        self.unlabeled_values
+    pub(crate) fn unlabeled_fields(&self) -> bool {
+        self.unlabeled_fields
     }
 
-    pub(crate) fn unindexed_values(&self) -> bool {
-        self.unindexed_values
+    pub(crate) fn unindexed_fields(&self) -> bool {
+        self.unindexed_fields
     }
 }
 
@@ -94,8 +94,8 @@ pub(crate) fn derive_struct<'a>(
         attrs.tag(),
         Some(label_or_ident(attrs.label(), ident)),
         attrs.index(),
-        attrs.unlabeled_values(),
-        attrs.unindexed_values(),
+        attrs.unlabeled_fields(),
+        attrs.unindexed_fields(),
     );
 
     let tag = quote_optional_tag_owned(attrs.tag());

--- a/derive_macros/src/stream/stream_record_tuple.rs
+++ b/derive_macros/src/stream/stream_record_tuple.rs
@@ -32,8 +32,8 @@ pub(crate) fn stream_record_tuple<'a>(
     tag: Option<&Path>,
     label: Option<Label>,
     index: Option<Index>,
-    unlabeled_values: bool,
-    unindexed_values: bool,
+    unlabeled_fields: bool,
+    unindexed_fields: bool,
 ) -> proc_macro2::TokenStream {
     let tag = quote_optional_tag(tag);
     let label = quote_optional_label(label);
@@ -79,7 +79,7 @@ pub(crate) fn stream_record_tuple<'a>(
             attr::get_unchecked("struct field", attr::TagAttr, &field.attrs).as_ref(),
         );
 
-        let label = if unlabeled_values {
+        let label = if unlabeled_fields {
             attr::ensure_missing("struct field", attr::LabelAttr, &field.attrs);
 
             None
@@ -90,7 +90,7 @@ pub(crate) fn stream_record_tuple<'a>(
             )
         };
 
-        let index = if unindexed_values {
+        let index = if unindexed_fields {
             attr::ensure_missing("struct field", attr::IndexAttr, &field.attrs);
 
             None

--- a/flatten/Cargo.toml
+++ b/flatten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_flatten"
-version = "0.0.0"
+version = "2.6.1"
 description = "Value flattening for sval"
 edition = "2021"
 

--- a/flatten/src/map.rs
+++ b/flatten/src/map.rs
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn flatten_record() {
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Inner {
             b: i32,
             c: i32,

--- a/flatten/src/record_tuple.rs
+++ b/flatten/src/record_tuple.rs
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn flatten_record() {
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Inner {
             b: i32,
             c: i32,

--- a/flatten/src/seq.rs
+++ b/flatten/src/seq.rs
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn flatten_record() {
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Inner {
             b: i32,
             c: i32,

--- a/flatten/src/tuple.rs
+++ b/flatten/src/tuple.rs
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn flatten_record() {
         #[derive(Value)]
-        #[sval(unindexed_values)]
+        #[sval(unindexed_fields)]
         struct Inner {
             b: i32,
             c: i32,

--- a/src/data/map.rs
+++ b/src/data/map.rs
@@ -8,7 +8,7 @@ pub struct MapSlice<K, V>([(K, V)]);
 
 impl<K, V> MapSlice<K, V> {
     /**
-    Treat a slice of 8bit unsigned integers as binary.
+    Treat a slice of key-value pairs as a map.
      */
     pub fn new<'a>(map: &'a [(K, V)]) -> &'a Self {
         // SAFETY: `MapSlice` and `[(K, V)]` have the same ABI

--- a/src/data/tags.rs
+++ b/src/data/tags.rs
@@ -78,6 +78,10 @@ pub const CONSTANT_SIZE: Tag = Tag::new("CONSTANT_SIZE");
 A tag for labels that are valid Rust identifiers.
 
 `sval` uses this tag by default for labels on record values and enum variants.
+
+# Valid datatypes
+
+- `label`
  */
 pub const VALUE_IDENT: Tag = Tag::new("VALUE_IDENT");
 
@@ -85,5 +89,9 @@ pub const VALUE_IDENT: Tag = Tag::new("VALUE_IDENT");
 A tag for indexes that are zero-based non-negative offsets into a larger structure.
 
 `sval` uses this tag by default for indexes on tuple values and enum variants.
+
+# Valid datatypes
+
+- `index`
 */
 pub const VALUE_OFFSET: Tag = Tag::new("VALUE_OFFSET");


### PR DESCRIPTION
This PR just gets things ready for the next release by documenting `sval_derive` and making some last minute naming changes.