### PR TITLE
Add more tests for flatten and fix an indexing issue

### DIFF
--- a/derive_macros/README.md
+++ b/derive_macros/README.md
@@ -1,7 +1,8 @@
-# `sval_derive`
+# `sval_derive_macros`
 
 [![Rust](https://github.com/sval-rs/sval/workflows/derive/badge.svg)](https://github.com/sval-rs/sval/actions)
 [![Latest version](https://img.shields.io/crates/v/sval.svg)](https://crates.io/crates/sval_derive)
 [![Documentation Latest](https://docs.rs/sval_derive/badge.svg)](https://docs.rs/sval_derive)
 
-Automatically derive `sval::Value`.
+Automatically derive `sval::Value`. This library is an internal implementation detail of `sval`
+and shouldn't be depended on directly.

--- a/flatten/Cargo.toml
+++ b/flatten/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "sval_flatten"
 version = "2.6.1"
-description = "Value flattening for sval"
+authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
+license = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/sval_flatten"
+description = "Value flattening for sval"
+repository = "https://github.com/sval-rs/sval"
+readme = "README.md"
+keywords = ["serialization", "no_std"]
+categories = ["encoding", "no-std"]
 
 [features]
 alloc = ["sval/alloc", "sval_buffer/alloc"]

--- a/flatten/LICENSE-APACHE
+++ b/flatten/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/flatten/LICENSE-MIT
+++ b/flatten/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/flatten/README.md
+++ b/flatten/README.md
@@ -1,0 +1,7 @@
+# `sval_flatten`
+
+[![Rust](https://github.com/sval-rs/sval/workflows/flatten/badge.svg)](https://github.com/sval-rs/sval/actions)
+[![Latest version](https://img.shields.io/crates/v/sval.svg)](https://crates.io/crates/sval_flatten)
+[![Documentation Latest](https://docs.rs/sval_flatten/badge.svg)](https://docs.rs/sval_flatten)
+
+Flatten nested `sval::Value`s onto their parent.

--- a/flatten/src/flattener.rs
+++ b/flatten/src/flattener.rs
@@ -41,7 +41,7 @@ pub(crate) trait Flatten<'sval> {
 }
 
 impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
-    pub(crate) fn begin(stream: S, start_from: usize) -> Self {
+    pub(crate) fn begin(stream: S, start_from: isize) -> Self {
         Flattener {
             stream,
             state: FlattenerState {
@@ -54,7 +54,7 @@ impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
         }
     }
 
-    pub(crate) fn end(self) -> usize {
+    pub(crate) fn end(self) -> isize {
         self.state.index_alloc.current_offset()
     }
 

--- a/flatten/src/index.rs
+++ b/flatten/src/index.rs
@@ -1,12 +1,12 @@
 use sval::Index;
 
 pub(crate) struct IndexAllocator {
-    initial_offset: usize,
-    current_offset: usize,
+    initial_offset: isize,
+    current_offset: isize,
 }
 
 impl IndexAllocator {
-    pub(crate) fn start_from(offset: usize) -> Self {
+    pub(crate) fn start_from(offset: isize) -> Self {
         IndexAllocator {
             initial_offset: offset,
             current_offset: offset,
@@ -16,27 +16,28 @@ impl IndexAllocator {
     pub(crate) fn next_begin(&mut self, incoming: Option<&Index>) -> Index {
         match incoming {
             // If there's an incoming tag then merge it into the current set
-            Some(incoming) => match (incoming.tag(), incoming.to_usize()) {
+            Some(incoming) => match (incoming.tag(), incoming.to_isize()) {
                 // If the incoming tag is a value offset then increment it by our starting point
                 (Some(&sval::tags::VALUE_OFFSET), Some(incoming)) => {
-                    Index::new(incoming + self.initial_offset).with_tag(&sval::tags::VALUE_OFFSET)
+                    Index::new_isize(incoming + self.initial_offset)
+                        .with_tag(&sval::tags::VALUE_OFFSET)
                 }
                 // If the incoming tag is not a value offset then just use it directly
                 _ => incoming.clone(),
             },
             // If there's no incoming tag then construct one
-            None => Index::new(self.current_offset).with_tag(&sval::tags::VALUE_OFFSET),
+            None => Index::new_isize(self.current_offset).with_tag(&sval::tags::VALUE_OFFSET),
         }
     }
 
     pub(crate) fn next_end(&mut self, incoming: Option<&Index>) -> Index {
         let index = self.next_begin(incoming);
-        self.current_offset += 1;
+        self.current_offset = index.to_isize().unwrap_or(self.current_offset) + 1;
 
         index
     }
 
-    pub(crate) fn current_offset(&self) -> usize {
+    pub(crate) fn current_offset(&self) -> isize {
         self.current_offset
     }
 }

--- a/flatten/src/map.rs
+++ b/flatten/src/map.rs
@@ -11,8 +11,8 @@ with the length of the map after flattening the value.
 pub fn flatten_to_map<'sval>(
     stream: &mut (impl Stream<'sval> + ?Sized),
     value: &'sval (impl sval::Value + ?Sized),
-    offset: usize,
-) -> sval::Result<usize> {
+    offset: isize,
+) -> sval::Result<isize> {
     let stream = PassThru::new(stream);
 
     let mut stream = Flattener::begin(MapFlatten { stream }, offset);

--- a/flatten/src/record.rs
+++ b/flatten/src/record.rs
@@ -13,8 +13,8 @@ with the length of the record after flattening the value.
 pub fn flatten_to_record<'sval>(
     stream: &mut (impl Stream<'sval> + ?Sized),
     value: &'sval (impl sval::Value + ?Sized),
-    offset: usize,
-) -> sval::Result<usize> {
+    offset: isize,
+) -> sval::Result<isize> {
     let label_stream = LabelBuf::default();
 
     let mut stream = Flattener::begin(

--- a/flatten/src/tuple.rs
+++ b/flatten/src/tuple.rs
@@ -13,8 +13,8 @@ with the length of the tuple after flattening the value.
 pub fn flatten_to_tuple<'sval>(
     stream: &mut (impl Stream<'sval> + ?Sized),
     value: &'sval (impl sval::Value + ?Sized),
-    offset: usize,
-) -> sval::Result<usize> {
+    offset: isize,
+) -> sval::Result<isize> {
     let label_stream = Empty;
 
     let mut stream = Flattener::begin(
@@ -77,12 +77,12 @@ mod tests {
 
             stream.tuple_value_begin(
                 None,
-                &Index::new(offset).with_tag(&sval::tags::VALUE_OFFSET),
+                &Index::from(offset).with_tag(&sval::tags::VALUE_OFFSET),
             )?;
             stream.i32(self.0)?;
             stream.tuple_value_end(
                 None,
-                &Index::new(offset).with_tag(&sval::tags::VALUE_OFFSET),
+                &Index::from(offset).with_tag(&sval::tags::VALUE_OFFSET),
             )?;
             offset += 1;
 
@@ -90,12 +90,12 @@ mod tests {
 
             stream.tuple_value_begin(
                 None,
-                &Index::new(offset).with_tag(&sval::tags::VALUE_OFFSET),
+                &Index::from(offset).with_tag(&sval::tags::VALUE_OFFSET),
             )?;
             stream.i32(self.2)?;
             stream.tuple_value_end(
                 None,
-                &Index::new(offset).with_tag(&sval::tags::VALUE_OFFSET),
+                &Index::from(offset).with_tag(&sval::tags::VALUE_OFFSET),
             )?;
             offset += 1;
 


### PR DESCRIPTION
This PR makes sure we use the same approach to assigning indexes when flattening as we do in `sval_derive`. I've also filled in some more exotic test cases for flattening just to make sure it produces well-formed results with some less common inputs.