### PR TITLE
Prepare for 2.7.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -41,7 +41,7 @@ alloc = []
 derive = ["dep:sval_derive_macros"]
 
 [dependencies.sval_derive_macros]
-version = "2.6.1"
+version = "2.7.0"
 path = "derive_macros"
 optional = true
 

--- a/buffer/Cargo.toml
+++ b/buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_buffer"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -21,17 +21,17 @@ alloc = ["sval/alloc"]
 no_debug_assertions = []
 
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 path = "../"
 
 [dependencies.sval_ref]
-version = "2.6.1"
+version = "2.7.0"
 path = "../ref"
 
 [dev-dependencies.sval_derive]
-version = "2.6.1"
+version = "2.7.0"
 path = "../derive"
 
 [dev-dependencies.sval_test]
-version = "2.6.1"
+version = "2.7.0"
 path = "../test"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -17,10 +17,10 @@ std = ["sval_flatten?/std"]
 flatten = ["dep:sval_flatten", "sval_derive_macros/flatten"]
 
 [dependencies.sval_derive_macros]
-version = "2.6.1"
+version = "2.7.0"
 path = "../derive_macros"
 
 [dependencies.sval_flatten]
-version = "2.6.1"
+version = "2.7.0"
 path = "../flatten"
 optional = true

--- a/derive_macros/Cargo.toml
+++ b/derive_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_derive_macros"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/dynamic/Cargo.toml
+++ b/dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_dynamic"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -12,5 +12,5 @@ keywords = ["serialization", "no_std"]
 categories = ["encoding", "no-std"]
 
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 path = "../"

--- a/flatten/Cargo.toml
+++ b/flatten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_flatten"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/flatten/Cargo.toml
+++ b/flatten/Cargo.toml
@@ -16,10 +16,12 @@ alloc = ["sval/alloc", "sval_buffer/alloc"]
 std = ["alloc", "sval/std", "sval_buffer/std"]
 
 [dependencies.sval]
+version = "2.7.0"
 path = "../"
 default-features = false
 
 [dependencies.sval_buffer]
+version = "2.7.0"
 path = "../buffer"
 default-features = false
 

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_fmt"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -19,7 +19,7 @@ std = ["alloc", "sval/std"]
 alloc = ["sval/alloc"]
 
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 path = "../"
 
 [dependencies.ryu]

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_json"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -19,7 +19,7 @@ std = ["alloc", "sval/std"]
 alloc = ["sval/alloc"]
 
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 path = "../"
 
 [dependencies.ryu]

--- a/ref/Cargo.toml
+++ b/ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_ref"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -16,9 +16,9 @@ std = ["alloc", "sval/std"]
 alloc = ["sval/alloc"]
 
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 path = "../"
 
 [dev-dependencies.sval_test]
-version = "2.6.1"
+version = "2.7.0"
 path = "../test"

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_serde"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -19,16 +19,16 @@ std = ["alloc", "serde/std", "sval/std", "sval_buffer/std"]
 alloc = ["serde/alloc", "sval/alloc", "sval_buffer/alloc"]
 
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 path = "../"
 
 [dependencies.sval_buffer]
-version = "2.6.1"
+version = "2.7.0"
 path = "../buffer"
 default-features = false
 
 [dependencies.sval_fmt]
-version = "2.6.1"
+version = "2.7.0"
 path = "../fmt"
 
 [dependencies.serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ Add `sval` to your `Cargo.toml`:
 
 ```toml
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 ```
 
 By default, `sval` doesn't depend on Rust's standard library or integrate
@@ -24,7 +24,7 @@ with its collection types. To include them, add the `alloc` or `std` features:
 
 ```toml
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 features = ["std"]
 ```
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sval_test"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -12,15 +12,15 @@ keywords = ["serialization", "no_std"]
 categories = ["encoding", "no-std"]
 
 [dependencies.sval]
-version = "2.6.1"
+version = "2.7.0"
 path = "../"
 features = ["std"]
 
 [dependencies.sval_fmt]
-version = "2.6.1"
+version = "2.7.0"
 path = "../fmt"
 features = ["std"]
 
 [dev-dependencies.sval_dynamic]
-version = "2.6.1"
+version = "2.7.0"
 path = "../dynamic"


### PR DESCRIPTION
## What's Changed
* Test minimal versions by @KodrAus in https://github.com/sval-rs/sval/pull/152
* Add support for types that can be records or tuples by @KodrAus in https://github.com/sval-rs/sval/pull/153
* Support negative index values by @KodrAus in https://github.com/sval-rs/sval/pull/154
* Split up derive and make test assertions better by @KodrAus in https://github.com/sval-rs/sval/pull/155
* Add flattening, unindexed, unlabeled, dynamic, transparent support by @KodrAus in https://github.com/sval-rs/sval/pull/156
* Add support for wrapping value data in tags by @KodrAus in https://github.com/sval-rs/sval/pull/157
* Pepper some inlines about by @KodrAus in https://github.com/sval-rs/sval/pull/158
* Rename some unstable attributes and document sval_derive by @KodrAus in https://github.com/sval-rs/sval/pull/159
* Add more tests for flatten and fix an indexing issue by @KodrAus in https://github.com/sval-rs/sval/pull/160