### PR TITLE
Add Debug impls to some types

### DIFF
--- a/src/data/binary.rs
+++ b/src/data/binary.rs
@@ -1,4 +1,4 @@
-use crate::{tags, Result, Stream, Value};
+use crate::{tags, Result, Stream, Value, std::fmt};
 
 /**
 An adapter that streams a slice of 8bit unsigned integers as binary.
@@ -24,6 +24,12 @@ impl BinarySlice {
     #[inline(always)]
     pub fn as_slice(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl fmt::Debug for BinarySlice {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
     }
 }
 
@@ -71,6 +77,12 @@ impl<const N: usize> BinaryArray<N> {
     #[inline(always)]
     pub fn as_slice(&self) -> &[u8; N] {
         &self.0
+    }
+}
+
+impl<const N: usize> fmt::Debug for BinaryArray<N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
     }
 }
 

--- a/src/data/map.rs
+++ b/src/data/map.rs
@@ -1,4 +1,4 @@
-use crate::{Result, Stream, Value};
+use crate::{Result, Stream, Value, std::fmt};
 
 /**
 An adapter that streams a slice of key-value pairs as a map.
@@ -20,6 +20,12 @@ impl<K, V> MapSlice<K, V> {
      */
     pub fn as_slice(&self) -> &[(K, V)] {
         &self.0
+    }
+}
+
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for MapSlice<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
     }
 }
 


### PR DESCRIPTION
This PR just adds some trivial Debug impls to `BinarySlice`, `BinaryArray`, and `MapSlice`.