### PR TITLE
Add a JsonStr type for encoded JSON buffers

### DIFF
--- a/fmt/src/to_value.rs
+++ b/fmt/src/to_value.rs
@@ -40,7 +40,7 @@ impl<V: fmt::Debug + ?Sized> DebugToValue<V> {
     Adapt a reference to a [`fmt::Debug`] into an [`sval::Value`].
     */
     pub fn new_borrowed<'a>(value: &'a V) -> &'a DebugToValue<V> {
-        // SAFETY: `&'a V` and `&'a ToDebug<V>` have the same ABI
+        // SAFETY: `&'a V` and `&'a DebugToValue<V>` have the same ABI
         unsafe { &*(value as *const _ as *const DebugToValue<V>) }
     }
 }
@@ -65,7 +65,7 @@ impl<V: fmt::Display + ?Sized> DisplayToValue<V> {
     Adapt a reference to a [`fmt::Display`] into an [`sval::Value`].
     */
     pub fn new_borrowed<'a>(value: &'a V) -> &'a DisplayToValue<V> {
-        // SAFETY: `&'a V` and `&'a ToDebug<V>` have the same ABI
+        // SAFETY: `&'a V` and `&'a DisplayToValue<V>` have the same ABI
         unsafe { &*(value as *const _ as *const DisplayToValue<V>) }
     }
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -15,6 +15,9 @@ extern crate std;
 
 mod error;
 
+mod value;
+pub use self::value::*;
+
 mod to_fmt;
 pub use self::{error::*, to_fmt::*};
 

--- a/json/src/tags.rs
+++ b/json/src/tags.rs
@@ -3,6 +3,15 @@ Tags for JSON-specific types.
 */
 
 /**
+A tag for strings that contain an embedded JSON value.
+
+# Valid datatypes
+
+- `text`
+*/
+pub const JSON_VALUE: sval::Tag = sval::Tag::new("JSON_VALUE");
+
+/**
 A tag for strings that either don't contain characters that need escaping or are already escaped.
 
 # Valid datatypes

--- a/json/src/to_fmt.rs
+++ b/json/src/to_fmt.rs
@@ -296,6 +296,10 @@ where
             Some(&tags::JSON_TEXT) => {
                 self.text_handler = Some(TextHandler::native());
             }
+            Some(&tags::JSON_VALUE) => {
+                self.is_text_quoted = false;
+                self.text_handler = Some(TextHandler::native());
+            }
             Some(&sval::tags::NUMBER) => {
                 self.is_text_quoted = false;
 
@@ -321,6 +325,10 @@ where
     ) -> sval::Result {
         match tag {
             Some(&tags::JSON_TEXT) => {
+                self.text_handler = None;
+            }
+            Some(&tags::JSON_VALUE) => {
+                self.is_text_quoted = true;
                 self.text_handler = None;
             }
             Some(&sval::tags::NUMBER) => {

--- a/json/src/to_string.rs
+++ b/json/src/to_string.rs
@@ -1,6 +1,6 @@
-use crate::Error;
+use crate::{Error, JsonStr};
 
-use alloc::string::String;
+use alloc::{boxed::Box, string::String};
 
 /**
 Stream a value as JSON into a string.
@@ -12,4 +12,13 @@ pub fn stream_to_string(v: impl sval::Value) -> Result<String, Error> {
     crate::stream_to_fmt_write(&mut out, v)?;
 
     Ok(out)
+}
+
+/**
+Stream a value as JSON into a `JsonStr`.
+
+This method will fail if the value contains complex values as keys.
+*/
+pub fn stream_to_json_str(v: impl sval::Value) -> Result<Box<JsonStr>, Error> {
+    Ok(JsonStr::boxed(stream_to_string(v)?))
 }

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -1,0 +1,73 @@
+use core::fmt;
+
+/**
+A string containing encoded JSON.
+
+Streaming a `JsonStr` will embed its contents directly rather
+than treating them as a string.
+*/
+#[repr(transparent)]
+#[derive(PartialEq, Eq, Hash)]
+pub struct JsonStr(str);
+
+impl JsonStr {
+    /**
+    Treat a string as native JSON.
+    */
+    pub fn new<'a>(json: &'a str) -> &'a Self {
+        // SAFETY: `JsonStr` and `str` have the same ABI
+        unsafe { &*(json as *const _ as *const JsonStr) }
+    }
+
+    /**
+    Get a reference to the underlying string.
+    */
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for JsonStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for JsonStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl PartialEq<str> for JsonStr {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl sval::Value for JsonStr {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        stream.tagged_begin(Some(&crate::tags::JSON_VALUE), None, None)?;
+        stream.value(&self.0)?;
+        stream.tagged_end(Some(&crate::tags::JSON_VALUE), None, None)
+    }
+}
+
+#[cfg(feature = "alloc")]
+mod alloc_support {
+    use super::*;
+
+    use alloc::boxed::Box;
+
+    impl JsonStr {
+        /**
+        Treat a string as native JSON.
+        */
+        pub fn boxed(json: impl Into<Box<str>>) -> Box<Self> {
+            let json = json.into();
+
+            // SAFETY: `JsonStr` and `str` have the same ABI
+            unsafe { Box::from_raw(Box::into_raw(json) as *mut str as *mut JsonStr) }
+        }
+    }
+}

--- a/json/test/lib.rs
+++ b/json/test/lib.rs
@@ -16,8 +16,13 @@ fn assert_stream(expected: &str, v: impl sval::Value) {
     let actual_string = sval_json::stream_to_string(&v).unwrap();
     let actual_bytes = String::from_utf8(sval_json::stream_to_vec(&v).unwrap()).unwrap();
 
+    let actual_json_str = sval_json::stream_to_json_str(&v).unwrap();
+    let rountrip_json_str = sval_json::stream_to_string(&actual_json_str).unwrap();
+
     assert_eq!(expected, actual_string);
     assert_eq!(expected, actual_bytes);
+    assert_eq!(expected, actual_json_str.as_str());
+    assert_eq!(expected, rountrip_json_str);
 }
 
 fn assert_valid(v: impl sval::Value) {


### PR DESCRIPTION
This PR introduces a `JsonStr` type to `sval_json` that can be used to embed pre-encoded JSON into larger values without re-interpreting them.