### PR TITLE
Fix a bug ending enums in flattened values

### DIFF
--- a/flatten/src/flattener.rs
+++ b/flatten/src/flattener.rs
@@ -10,6 +10,7 @@ pub(crate) struct Flattener<'sval, S> {
     state: FlattenerState<'sval>,
 }
 
+#[derive(Debug)]
 struct FlattenerState<'sval> {
     index_alloc: IndexAllocator,
     key_buf: LabelBuf<'sval>,
@@ -379,7 +380,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         self.value_at_root(
             |_, _| Ok(()),
             |buf| buf.enum_end(tag, label, index),
-            |stream| stream.enum_begin(tag, label, index),
+            |stream| stream.enum_end(tag, label, index),
         )
     }
 

--- a/flatten/src/index.rs
+++ b/flatten/src/index.rs
@@ -1,5 +1,6 @@
 use sval::Index;
 
+#[derive(Debug)]
 pub(crate) struct IndexAllocator {
     initial_offset: isize,
     current_offset: isize,

--- a/flatten/src/label.rs
+++ b/flatten/src/label.rs
@@ -13,6 +13,7 @@ impl<'a, 'sval, S: LabelStream<'sval> + ?Sized> LabelStream<'sval> for &'a mut S
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum LabelBuf<'sval> {
     Empty,
     Text(TextBuf<'sval>),

--- a/src/data/binary.rs
+++ b/src/data/binary.rs
@@ -1,4 +1,4 @@
-use crate::{tags, Result, Stream, Value, std::fmt};
+use crate::{std::fmt, tags, Result, Stream, Value};
 
 /**
 An adapter that streams a slice of 8bit unsigned integers as binary.

--- a/src/data/map.rs
+++ b/src/data/map.rs
@@ -1,4 +1,4 @@
-use crate::{Result, Stream, Value, std::fmt};
+use crate::{std::fmt, Result, Stream, Value};
 
 /**
 An adapter that streams a slice of key-value pairs as a map.


### PR DESCRIPTION
We were calling `enum_begin` instead of `enum_end` in `sval_flatten` when attempting to finish an enum.