### PR TITLE
Mark more ctors as const

### DIFF
--- a/fmt/src/to_value.rs
+++ b/fmt/src/to_value.rs
@@ -30,7 +30,7 @@ impl<V: fmt::Debug> DebugToValue<V> {
     /**
     Adapt a [`fmt::Debug`] into an [`sval::Value`].
     */
-    pub fn new(value: V) -> DebugToValue<V> {
+    pub const fn new(value: V) -> DebugToValue<V> {
         DebugToValue(value)
     }
 }
@@ -39,7 +39,7 @@ impl<V: fmt::Debug + ?Sized> DebugToValue<V> {
     /**
     Adapt a reference to a [`fmt::Debug`] into an [`sval::Value`].
     */
-    pub fn new_borrowed<'a>(value: &'a V) -> &'a DebugToValue<V> {
+    pub const fn new_borrowed<'a>(value: &'a V) -> &'a DebugToValue<V> {
         // SAFETY: `&'a V` and `&'a DebugToValue<V>` have the same ABI
         unsafe { &*(value as *const _ as *const DebugToValue<V>) }
     }
@@ -55,7 +55,7 @@ impl<V: fmt::Display> DisplayToValue<V> {
     /**
     Adapt a [`fmt::Display`] into an [`sval::Value`].
     */
-    pub fn new(value: V) -> DisplayToValue<V> {
+    pub const fn new(value: V) -> DisplayToValue<V> {
         DisplayToValue(value)
     }
 }
@@ -64,7 +64,7 @@ impl<V: fmt::Display + ?Sized> DisplayToValue<V> {
     /**
     Adapt a reference to a [`fmt::Display`] into an [`sval::Value`].
     */
-    pub fn new_borrowed<'a>(value: &'a V) -> &'a DisplayToValue<V> {
+    pub const fn new_borrowed<'a>(value: &'a V) -> &'a DisplayToValue<V> {
         // SAFETY: `&'a V` and `&'a DisplayToValue<V>` have the same ABI
         unsafe { &*(value as *const _ as *const DisplayToValue<V>) }
     }

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -14,7 +14,7 @@ impl JsonStr {
     /**
     Treat a string as native JSON.
     */
-    pub fn new<'a>(json: &'a str) -> &'a Self {
+    pub const fn new<'a>(json: &'a str) -> &'a Self {
         // SAFETY: `JsonStr` and `str` have the same ABI
         unsafe { &*(json as *const _ as *const JsonStr) }
     }
@@ -22,7 +22,7 @@ impl JsonStr {
     /**
     Get a reference to the underlying string.
     */
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/serde/src/to_serialize.rs
+++ b/serde/src/to_serialize.rs
@@ -28,7 +28,7 @@ impl<V: sval::Value> ToSerialize<V> {
     /**
     Adapt an [`sval::Value`] into a [`serde::Serialize`].
     */
-    pub fn new(value: V) -> ToSerialize<V> {
+    pub const fn new(value: V) -> ToSerialize<V> {
         ToSerialize(value)
     }
 }
@@ -37,7 +37,7 @@ impl<V: sval::Value + ?Sized> ToSerialize<V> {
     /**
     Adapt a reference to an [`sval::Value`] into a [`serde::Serialize`].
     */
-    pub fn new_borrowed<'a>(value: &'a V) -> &'a ToSerialize<V> {
+    pub const fn new_borrowed<'a>(value: &'a V) -> &'a ToSerialize<V> {
         // SAFETY: `&'a V` and `&'a ToSerialize<V>` have the same ABI
         unsafe { &*(value as *const _ as *const ToSerialize<V>) }
     }

--- a/serde/src/to_value.rs
+++ b/serde/src/to_value.rs
@@ -22,7 +22,7 @@ impl<V: serde::Serialize> ToValue<V> {
     /**
     Adapt a [`serde::Serialize`] into a [`sval::Value`].
     */
-    pub fn new(value: V) -> ToValue<V> {
+    pub const fn new(value: V) -> ToValue<V> {
         ToValue(value)
     }
 }
@@ -31,7 +31,7 @@ impl<V: serde::Serialize + ?Sized> ToValue<V> {
     /**
     Adapt a reference to a [`serde::Serialize`] into an [`sval::Value`].
     */
-    pub fn new_borrowed<'a>(value: &'a V) -> &'a ToValue<V> {
+    pub const fn new_borrowed<'a>(value: &'a V) -> &'a ToValue<V> {
         // SAFETY: `&'a V` and `&'a ToValue<V>` have the same ABI
         unsafe { &*(value as *const _ as *const ToValue<V>) }
     }

--- a/src/data/binary.rs
+++ b/src/data/binary.rs
@@ -13,7 +13,7 @@ impl BinarySlice {
     Treat a slice of 8bit unsigned integers as binary.
     */
     #[inline(always)]
-    pub fn new<'a>(binary: &'a [u8]) -> &'a Self {
+    pub const fn new<'a>(binary: &'a [u8]) -> &'a Self {
         // SAFETY: `Binary` and `[u8]` have the same ABI
         unsafe { &*(binary as *const _ as *const BinarySlice) }
     }
@@ -22,7 +22,7 @@ impl BinarySlice {
     Get a reference to the underlying slice.
     */
     #[inline(always)]
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &[u8] {
         &self.0
     }
 }
@@ -66,7 +66,7 @@ impl<const N: usize> BinaryArray<N> {
     Treat a slice of 8bit unsigned integers as binary.
     */
     #[inline(always)]
-    pub fn new<'a>(binary: &'a [u8; N]) -> &'a Self {
+    pub const fn new<'a>(binary: &'a [u8; N]) -> &'a Self {
         // SAFETY: `Binary` and `[u8; N]` have the same ABI
         unsafe { &*(binary as *const _ as *const BinaryArray<N>) }
     }
@@ -75,7 +75,7 @@ impl<const N: usize> BinaryArray<N> {
     Get a reference to the underlying slice.
     */
     #[inline(always)]
-    pub fn as_slice(&self) -> &[u8; N] {
+    pub const fn as_slice(&self) -> &[u8; N] {
         &self.0
     }
 }

--- a/src/data/map.rs
+++ b/src/data/map.rs
@@ -10,7 +10,7 @@ impl<K, V> MapSlice<K, V> {
     /**
     Treat a slice of key-value pairs as a map.
      */
-    pub fn new<'a>(map: &'a [(K, V)]) -> &'a Self {
+    pub const fn new<'a>(map: &'a [(K, V)]) -> &'a Self {
         // SAFETY: `MapSlice` and `[(K, V)]` have the same ABI
         unsafe { &*(map as *const _ as *const MapSlice<K, V>) }
     }
@@ -18,7 +18,7 @@ impl<K, V> MapSlice<K, V> {
     /**
     Get a reference to the underlying slice.
      */
-    pub fn as_slice(&self) -> &[(K, V)] {
+    pub const fn as_slice(&self) -> &[(K, V)] {
         &self.0
     }
 }


### PR DESCRIPTION
This PR just marks most trivial constructors as `const`.