### PR TITLE
Derive enhancements

### DIFF
--- a/derive/test/compile_fail/union.rs
+++ b/derive/test/compile_fail/union.rs
@@ -1,0 +1,11 @@
+use sval_derive::*;
+
+#[derive(Value)]
+pub union Union {
+    a: i32,
+    b: u32,
+}
+
+fn main() {
+
+}

--- a/derive/test/compile_fail/union.stderr
+++ b/derive/test/compile_fail/union.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> compile_fail/union.rs:3:10
+  |
+3 | #[derive(Value)]
+  |          ^^^^^
+  |
+  = help: message: unsupported container type

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -27,6 +27,26 @@ mod derive_struct {
     }
 
     #[test]
+    fn generic() {
+        #[derive(Value)]
+        struct RecordTuple<S> {
+            a: S,
+        }
+
+        assert_tokens(&RecordTuple { a: 42 }, {
+            use sval_test::Token::*;
+
+            &[
+                RecordTupleBegin(None, Some(sval::Label::new("RecordTuple")), None, Some(1)),
+                RecordTupleValueBegin(None, sval::Label::new("a"), sval::Index::new(0)),
+                I32(42),
+                RecordTupleValueEnd(None, sval::Label::new("a"), sval::Index::new(0)),
+                RecordTupleEnd(None, Some(sval::Label::new("RecordTuple")), None),
+            ]
+        })
+    }
+
+    #[test]
     fn indexed() {
         #[derive(Value)]
         struct RecordTuple {

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -48,10 +48,13 @@ mod derive_struct {
 
     #[test]
     fn indexed() {
+        const B_INDEX: sval::Index = sval::Index::new(3);
+
         #[derive(Value)]
         struct RecordTuple {
             #[sval(index = 1)]
             a: i32,
+            #[sval(index = B_INDEX)]
             b: i32,
         }
 
@@ -63,9 +66,9 @@ mod derive_struct {
                 RecordTupleValueBegin(None, sval::Label::new("a"), sval::Index::new(1)),
                 I32(42),
                 RecordTupleValueEnd(None, sval::Label::new("a"), sval::Index::new(1)),
-                RecordTupleValueBegin(None, sval::Label::new("b"), sval::Index::new(2)),
+                RecordTupleValueBegin(None, sval::Label::new("b"), sval::Index::new(3)),
                 I32(57),
-                RecordTupleValueEnd(None, sval::Label::new("b"), sval::Index::new(2)),
+                RecordTupleValueEnd(None, sval::Label::new("b"), sval::Index::new(3)),
                 RecordTupleEnd(None, Some(sval::Label::new("RecordTuple")), None),
             ]
         })
@@ -140,7 +143,7 @@ mod derive_struct {
     fn data_tagged() {
         #[derive(Value)]
         struct RecordTuple {
-            #[sval(data_tag = "sval::tags::NUMBER")]
+            #[sval(data_tag = sval::tags::NUMBER)]
             a: i32,
         }
 
@@ -236,7 +239,7 @@ mod derive_struct {
         const FIELD: sval::Tag = sval::Tag::new("field");
 
         #[derive(Value)]
-        #[sval(tag = "CONTAINER", label = "record", index = 0)]
+        #[sval(tag = CONTAINER, label = "record", index = 0)]
         struct Record {
             #[sval(tag = "FIELD", label = "field0")]
             a: i32,
@@ -329,8 +332,10 @@ mod derive_tuple {
 
     #[test]
     fn labeled() {
+        const B_LABEL: sval::Label<'static> = sval::Label::new("B");
+
         #[derive(Value)]
-        struct RecordTuple(#[sval(label = "A")] i32, #[sval(label = "B")] i32);
+        struct RecordTuple(#[sval(label = "A")] i32, #[sval(label = B_LABEL)] i32);
 
         assert_tokens(&RecordTuple(42, 43), {
             use sval_test::Token::*;

--- a/derive_macros/src/derive.rs
+++ b/derive_macros/src/derive.rs
@@ -43,6 +43,43 @@ pub(crate) fn derive(input: DeriveInput) -> proc_macro2::TokenStream {
 
             derive_enum(&input.ident, &input.generics, variants.iter(), &attrs)
         }
-        _ => panic!("unimplemented"),
+        _ => panic!("unsupported container type"),
+    }
+}
+
+fn impl_tokens(
+    impl_generics: syn::ImplGenerics,
+    ident: &syn::Ident,
+    ty_generics: syn::TypeGenerics,
+    bounded_where_clause: &syn::WhereClause,
+    stream_body: proc_macro2::TokenStream,
+    tag_body: Option<proc_macro2::TokenStream>,
+) -> proc_macro2::TokenStream {
+    let stream_fn = quote!(
+        fn stream<'sval, __SvalStream: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut __SvalStream) -> sval::Result {
+            #stream_body
+        }
+    );
+
+    let tag_fn = if let Some(tag_body) = tag_body {
+        quote!(
+            fn tag(&self) -> Option<sval::Tag> {
+                #tag_body
+            }
+        )
+    } else {
+        quote!()
+    };
+
+    quote! {
+        const _: () = {
+            extern crate sval;
+
+            impl #impl_generics sval::Value for #ident #ty_generics #bounded_where_clause {
+                #stream_fn
+
+                #tag_fn
+            }
+        };
     }
 }

--- a/derive_macros/src/derive/derive_newtype.rs
+++ b/derive_macros/src/derive/derive_newtype.rs
@@ -3,16 +3,16 @@ use syn::{Attribute, Field, Generics, Ident, Path};
 use crate::{
     attr, bound,
     derive::impl_tokens,
-    index::{Index, IndexAllocator},
-    label::label_or_ident,
+    index::{Index, IndexAllocator, IndexValue},
+    label::{label_or_ident, LabelValue},
     stream::stream_newtype,
     tag::quote_optional_tag_owned,
 };
 
 pub(crate) struct NewtypeAttrs {
     tag: Option<Path>,
-    label: Option<String>,
-    index: Option<isize>,
+    label: Option<LabelValue>,
+    index: Option<IndexValue>,
     transparent: bool,
 }
 
@@ -53,12 +53,12 @@ impl NewtypeAttrs {
         self.tag.as_ref()
     }
 
-    pub(crate) fn label(&self) -> Option<&str> {
-        self.label.as_deref()
+    pub(crate) fn label(&self) -> Option<LabelValue> {
+        self.label.clone()
     }
 
     pub(crate) fn index(&self) -> Option<Index> {
-        self.index.map(IndexAllocator::const_index_of)
+        self.index.clone().map(IndexAllocator::const_index_of)
     }
 
     pub(crate) fn transparent(&self) -> bool {

--- a/derive_macros/src/derive/derive_newtype.rs
+++ b/derive_macros/src/derive/derive_newtype.rs
@@ -1,8 +1,8 @@
 use syn::{Attribute, Field, Generics, Ident, Path};
 
 use crate::{
-    attr::{self},
-    bound,
+    attr, bound,
+    derive::impl_tokens,
     index::{Index, IndexAllocator},
     label::label_or_ident,
     stream::stream_newtype,
@@ -88,23 +88,18 @@ pub(crate) fn derive_newtype<'a>(
 
     let tag = quote_optional_tag_owned(attrs.tag());
 
-    quote! {
-        const _: () = {
-            extern crate sval;
-
-            impl #impl_generics sval::Value for #ident #ty_generics #bounded_where_clause {
-                fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
-                    match self {
-                        #match_arm
-                    }
-
-                    Ok(())
-                }
-
-                fn tag(&self) -> Option<sval::Tag> {
-                    #tag
-                }
+    impl_tokens(
+        impl_generics,
+        ident,
+        ty_generics,
+        &bounded_where_clause,
+        quote!({
+            match self {
+                #match_arm
             }
-        };
-    }
+
+            Ok(())
+        }),
+        Some(tag),
+    )
 }

--- a/derive_macros/src/derive/derive_struct.rs
+++ b/derive_macros/src/derive/derive_struct.rs
@@ -3,16 +3,16 @@ use syn::{Attribute, Fields, Generics, Ident, Path};
 use crate::{
     attr, bound,
     derive::impl_tokens,
-    index::{Index, IndexAllocator},
-    label::label_or_ident,
+    index::{Index, IndexAllocator, IndexValue},
+    label::{label_or_ident, LabelValue},
     stream::{stream_record_tuple, RecordTupleTarget},
     tag::quote_optional_tag_owned,
 };
 
 pub(crate) struct StructAttrs {
     tag: Option<Path>,
-    label: Option<String>,
-    index: Option<isize>,
+    label: Option<LabelValue>,
+    index: Option<IndexValue>,
     unlabeled_fields: bool,
     unindexed_fields: bool,
 }
@@ -53,12 +53,12 @@ impl StructAttrs {
         self.tag.as_ref()
     }
 
-    pub(crate) fn label(&self) -> Option<&str> {
-        self.label.as_deref()
+    pub(crate) fn label(&self) -> Option<LabelValue> {
+        self.label.clone()
     }
 
     pub(crate) fn index(&self) -> Option<Index> {
-        self.index.map(IndexAllocator::const_index_of)
+        self.index.clone().map(IndexAllocator::const_index_of)
     }
 
     pub(crate) fn unlabeled_fields(&self) -> bool {

--- a/derive_macros/src/derive/derive_struct.rs
+++ b/derive_macros/src/derive/derive_struct.rs
@@ -1,8 +1,8 @@
 use syn::{Attribute, Fields, Generics, Ident, Path};
 
 use crate::{
-    attr::{self},
-    bound,
+    attr, bound,
+    derive::impl_tokens,
     index::{Index, IndexAllocator},
     label::label_or_ident,
     stream::{stream_record_tuple, RecordTupleTarget},
@@ -100,23 +100,18 @@ pub(crate) fn derive_struct<'a>(
 
     let tag = quote_optional_tag_owned(attrs.tag());
 
-    quote! {
-        const _: () = {
-            extern crate sval;
-
-            impl #impl_generics sval::Value for #ident #ty_generics #bounded_where_clause {
-                fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
-                    match self {
-                        #match_arm
-                    }
-
-                    Ok(())
-                }
-
-                fn tag(&self) -> Option<sval::Tag> {
-                    #tag
-                }
+    impl_tokens(
+        impl_generics,
+        ident,
+        ty_generics,
+        &bounded_where_clause,
+        quote!({
+            match self {
+                #match_arm
             }
-        };
-    }
+
+            Ok(())
+        }),
+        Some(tag),
+    )
 }

--- a/derive_macros/src/derive/derive_unit_struct.rs
+++ b/derive_macros/src/derive/derive_unit_struct.rs
@@ -1,8 +1,8 @@
 use syn::{Attribute, Generics, Ident, Path};
 
 use crate::{
-    attr::{self},
-    bound,
+    attr, bound,
+    derive::impl_tokens,
     index::{Index, IndexAllocator},
     label::label_or_ident,
     stream::stream_tag,
@@ -62,23 +62,18 @@ pub(crate) fn derive_unit_struct<'a>(
 
     let tag = quote_optional_tag_owned(attrs.tag());
 
-    quote! {
-        const _: () = {
-            extern crate sval;
-
-            impl #impl_generics sval::Value for #ident #ty_generics #bounded_where_clause {
-                fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
-                    match self {
-                        #match_arm
-                    }
-
-                    Ok(())
-                }
-
-                fn tag(&self) -> Option<sval::Tag> {
-                    #tag
-                }
+    impl_tokens(
+        impl_generics,
+        ident,
+        ty_generics,
+        &bounded_where_clause,
+        quote!({
+            match self {
+                #match_arm
             }
-        };
-    }
+
+            Ok(())
+        }),
+        Some(tag),
+    )
 }

--- a/derive_macros/src/derive/derive_unit_struct.rs
+++ b/derive_macros/src/derive/derive_unit_struct.rs
@@ -3,16 +3,16 @@ use syn::{Attribute, Generics, Ident, Path};
 use crate::{
     attr, bound,
     derive::impl_tokens,
-    index::{Index, IndexAllocator},
-    label::label_or_ident,
+    index::{Index, IndexAllocator, IndexValue},
+    label::{label_or_ident, LabelValue},
     stream::stream_tag,
     tag::quote_optional_tag_owned,
 };
 
 pub(crate) struct UnitStructAttrs {
     tag: Option<Path>,
-    label: Option<String>,
-    index: Option<isize>,
+    label: Option<LabelValue>,
+    index: Option<IndexValue>,
 }
 
 impl UnitStructAttrs {
@@ -34,12 +34,12 @@ impl UnitStructAttrs {
         self.tag.as_ref()
     }
 
-    pub(crate) fn label(&self) -> Option<&str> {
-        self.label.as_deref()
+    pub(crate) fn label(&self) -> Option<LabelValue> {
+        self.label.clone()
     }
 
     pub(crate) fn index(&self) -> Option<Index> {
-        self.index.map(IndexAllocator::const_index_of)
+        self.index.clone().map(IndexAllocator::const_index_of)
     }
 }
 

--- a/derive_macros/src/derive/derive_void.rs
+++ b/derive_macros/src/derive/derive_void.rs
@@ -1,6 +1,6 @@
 use syn::{Attribute, Generics, Ident};
 
-use crate::{attr, bound};
+use crate::{attr, bound, derive::impl_tokens};
 
 pub(crate) struct VoidAttrs {}
 
@@ -24,15 +24,12 @@ pub(crate) fn derive_void<'a>(
     let bound = parse_quote!(sval::Value);
     let bounded_where_clause = bound::where_clause_with_bound(&generics, bound);
 
-    quote! {
-        const _: () = {
-            extern crate sval;
-
-            impl #impl_generics sval::Value for #ident #ty_generics #bounded_where_clause {
-                fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
-                    match *self {}
-                }
-            }
-        };
-    }
+    impl_tokens(
+        impl_generics,
+        ident,
+        ty_generics,
+        &bounded_where_clause,
+        quote!({ match *self {} }),
+        None,
+    )
 }

--- a/derive_macros/src/stream/stream_record_tuple.rs
+++ b/derive_macros/src/stream/stream_record_tuple.rs
@@ -1,6 +1,6 @@
 use syn::{spanned::Spanned, Field, Ident, Path};
 
-use crate::label::{optional_label_or_ident, Label};
+use crate::label::{optional_label_or_ident, Label, LabelValue};
 use crate::{
     attr::{self},
     index::{quote_index, quote_optional_index, Index, IndexAllocator},
@@ -275,8 +275,11 @@ fn get_field(index: &syn::Index, field: &Field) -> (Ident, proc_macro2::TokenStr
     }
 }
 
-fn get_label(explicit: Option<String>, ident: Option<&Ident>) -> Option<proc_macro2::TokenStream> {
-    optional_label_or_ident(explicit.as_deref(), ident).map(|label| quote_label(label))
+fn get_label(
+    explicit: Option<LabelValue>,
+    ident: Option<&Ident>,
+) -> Option<proc_macro2::TokenStream> {
+    optional_label_or_ident(explicit, ident).map(|label| quote_label(label))
 }
 
 fn quote_field_skip(index: &syn::Index, field: &Field) -> proc_macro2::TokenStream {


### PR DESCRIPTION
Closes #170 
Closes #169 

There's still plenty to polish up in the `#[derive]` macros, particularly around error handling, but this makes it possible to use `const`s for labels and indexes in place of literals. The logic for determining an implicit index after an explicit one is to increment the last index if it was provided as a literal, or to just increment the internal counter if it was provided as a `const`.