### PR TITLE
Add some inlines to flatten

### DIFF
--- a/.github/workflows/flatten.yml
+++ b/.github/workflows/flatten.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Powerset
         working-directory: ./flatten
         run: cargo hack test --feature-powerset
+      
+      - name: Powerset (Benches)
+        working-directory: ./flatten/bench
+        run: cargo hack test --feature-powerset
 
       - name: Minimal Versions
         working-directory: ./flatten

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "json/test",
     "json/bench",
     "flatten",
+    "flatten/bench",
     "test",
     "experiments",
 ]

--- a/flatten/bench/Cargo.toml
+++ b/flatten/bench/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sval_flatten_bench"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[lib]
+path = "lib.rs"
+
+[dependencies.sval]
+path = "../../"
+features = ["std"]
+
+[dependencies.sval_flatten]
+path = "../"
+features = ["std"]
+
+[dependencies.sval_json]
+path = "../../json"
+features = ["std"]

--- a/flatten/bench/lib.rs
+++ b/flatten/bench/lib.rs
@@ -1,0 +1,185 @@
+#![feature(test)]
+
+extern crate test;
+
+struct RecordTuple {
+    before: u8,
+    flatten: Option<FlattenRecordTuple>,
+    after: u8,
+}
+
+impl sval::Value for RecordTuple {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        stream.record_tuple_begin(None, None, None, None)?;
+
+        stream_record_struct_fields(&mut *stream, self.before)?;
+
+        if let Some(ref flatten) = self.flatten {
+            sval_flatten::flatten_to_record_tuple(&mut *stream, flatten, self.before as isize)?;
+        }
+
+        stream_record_struct_fields(&mut *stream, self.after)?;
+
+        stream.record_tuple_end(None, None, None)
+    }
+}
+
+struct FlattenRecordTuple {
+    flatten: u8,
+}
+
+impl sval::Value for FlattenRecordTuple {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        stream.record_tuple_begin(None, None, None, None)?;
+
+        sval_flatten::flatten_to_record_tuple(&mut *stream, &self.flatten, 0)?;
+
+        stream.record_tuple_end(None, None, None)
+    }
+}
+
+fn stream_record_struct_fields<'sval>(
+    stream: &mut (impl sval::Stream<'sval> + ?Sized),
+    count: u8,
+) -> sval::Result {
+    for i in 0..count {
+        stream.record_tuple_value_begin(
+            None,
+            &sval::Label::new(FIELD_NAMES[i as usize]),
+            &sval::Index::new(i as usize).with_tag(&sval::tags::VALUE_OFFSET),
+        )?;
+        stream.u8(i)?;
+        stream.record_tuple_value_end(
+            None,
+            &sval::Label::new(FIELD_NAMES[i as usize]),
+            &sval::Index::new(i as usize).with_tag(&sval::tags::VALUE_OFFSET),
+        )?;
+    }
+
+    Ok(())
+}
+
+struct NullStream;
+
+impl<'sval> sval::Stream<'sval> for NullStream {
+    #[inline(never)]
+    fn null(&mut self) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn bool(&mut self, _: bool) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn text_fragment_computed(&mut self, _: &str) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn text_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn i64(&mut self, _: i64) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn f64(&mut self, _: f64) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn seq_value_begin(&mut self) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn seq_value_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn seq_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+}
+
+#[bench]
+fn unflatten_60(b: &mut test::Bencher) {
+    let record = RecordTuple {
+        before: 30,
+        flatten: None,
+        after: 30,
+    };
+
+    b.iter(|| sval::stream(&mut NullStream, &record))
+}
+
+#[bench]
+fn flatten_60(b: &mut test::Bencher) {
+    let record = RecordTuple {
+        before: 20,
+        flatten: Some(FlattenRecordTuple { flatten: 20 }),
+        after: 20,
+    };
+
+    b.iter(|| sval::stream(&mut NullStream, &record))
+}
+
+#[bench]
+fn json_unflatten_60(b: &mut test::Bencher) {
+    let record = RecordTuple {
+        before: 30,
+        flatten: None,
+        after: 30,
+    };
+
+    b.iter(|| sval_json::stream_to_string(&record))
+}
+
+#[bench]
+fn json_flatten_60(b: &mut test::Bencher) {
+    let record = RecordTuple {
+        before: 20,
+        flatten: Some(FlattenRecordTuple { flatten: 20 }),
+        after: 20,
+    };
+
+    b.iter(|| sval_json::stream_to_string(&record))
+}
+
+const FIELD_NAMES: &[&'static str] = &[
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
+    "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32",
+    "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48",
+    "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63", "64",
+    "65", "66", "67", "68", "69", "70", "71", "72", "73", "74", "75", "76", "77", "78", "79", "80",
+    "81", "82", "83", "84", "85", "86", "87", "88", "89", "90", "91", "92", "93", "94", "95", "96",
+    "97", "98", "99", "100", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110",
+    "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123",
+    "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136",
+    "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149",
+    "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162",
+    "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175",
+    "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188",
+    "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201",
+    "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214",
+    "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227",
+    "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240",
+    "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253",
+    "254",
+];

--- a/flatten/src/flattener.rs
+++ b/flatten/src/flattener.rs
@@ -42,6 +42,7 @@ pub(crate) trait Flatten<'sval> {
 }
 
 impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
+    #[inline]
     pub(crate) fn begin(stream: S, start_from: isize) -> Self {
         Flattener {
             stream,
@@ -55,10 +56,12 @@ impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
         }
     }
 
+    #[inline]
     pub(crate) fn end(self) -> isize {
         self.state.index_alloc.current_offset()
     }
 
+    #[inline]
     fn value(
         &mut self,
         buffer: impl FnOnce(&mut S::LabelStream) -> sval::Result,
@@ -68,6 +71,7 @@ impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
         self.value_at_root(|_, _| Ok(()), buffer, passthru)
     }
 
+    #[inline]
     fn value_at_root(
         &mut self,
         at_root: impl FnOnce(&mut S, &mut FlattenerState<'sval>) -> sval::Result,
@@ -83,6 +87,7 @@ impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
         }
     }
 
+    #[inline]
     fn flattenable_begin(
         &mut self,
         buffer: impl FnOnce(&mut S::LabelStream) -> sval::Result,
@@ -100,6 +105,7 @@ impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
         }
     }
 
+    #[inline]
     fn flattenable_value(
         &mut self,
         buffer: impl FnOnce(&mut S::LabelStream) -> sval::Result,
@@ -115,6 +121,7 @@ impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
         }
     }
 
+    #[inline]
     fn flattenable_end(
         &mut self,
         buffer: impl FnOnce(&mut S::LabelStream) -> sval::Result,
@@ -136,14 +143,17 @@ impl<'sval, S: Flatten<'sval>> Flattener<'sval, S> {
 }
 
 impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
+    #[inline]
     fn null(&mut self) -> sval::Result {
         self.value(|buf| buf.null(), |stream| stream.null())
     }
 
+    #[inline]
     fn bool(&mut self, value: bool) -> sval::Result {
         self.value(|buf| buf.bool(value), |stream| stream.bool(value))
     }
 
+    #[inline]
     fn text_begin(&mut self, num_bytes: Option<usize>) -> sval::Result {
         self.value(
             |buf| buf.text_begin(num_bytes),
@@ -151,6 +161,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn text_fragment(&mut self, fragment: &'sval str) -> sval::Result {
         self.value(
             |buf| buf.text_fragment(fragment),
@@ -158,6 +169,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn text_fragment_computed(&mut self, fragment: &str) -> sval::Result {
         self.value(
             |buf| buf.text_fragment_computed(fragment),
@@ -165,10 +177,12 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn text_end(&mut self) -> sval::Result {
         self.value(|buf| buf.text_end(), |stream| stream.text_end())
     }
 
+    #[inline]
     fn binary_begin(&mut self, num_bytes: Option<usize>) -> sval::Result {
         self.value(
             |buf| buf.binary_begin(num_bytes),
@@ -176,6 +190,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn binary_fragment(&mut self, fragment: &'sval [u8]) -> sval::Result {
         self.value(
             |buf| buf.binary_fragment(fragment),
@@ -183,6 +198,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn binary_fragment_computed(&mut self, fragment: &[u8]) -> sval::Result {
         self.value(
             |buf| buf.binary_fragment_computed(fragment),
@@ -190,58 +206,72 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn binary_end(&mut self) -> sval::Result {
         self.value(|buf| buf.binary_end(), |stream| stream.binary_end())
     }
 
+    #[inline]
     fn u8(&mut self, value: u8) -> sval::Result {
         self.value(|buf| buf.u8(value), |stream| stream.u8(value))
     }
 
+    #[inline]
     fn u16(&mut self, value: u16) -> sval::Result {
         self.value(|buf| buf.u16(value), |stream| stream.u16(value))
     }
 
+    #[inline]
     fn u32(&mut self, value: u32) -> sval::Result {
         self.value(|buf| buf.u32(value), |stream| stream.u32(value))
     }
 
+    #[inline]
     fn u64(&mut self, value: u64) -> sval::Result {
         self.value(|buf| buf.u64(value), |stream| stream.u64(value))
     }
 
+    #[inline]
     fn u128(&mut self, value: u128) -> sval::Result {
         self.value(|buf| buf.u128(value), |stream| stream.u128(value))
     }
 
+    #[inline]
     fn i8(&mut self, value: i8) -> sval::Result {
         self.value(|buf| buf.i8(value), |stream| stream.i8(value))
     }
 
+    #[inline]
     fn i16(&mut self, value: i16) -> sval::Result {
         self.value(|buf| buf.i16(value), |stream| stream.i16(value))
     }
 
+    #[inline]
     fn i32(&mut self, value: i32) -> sval::Result {
         self.value(|buf| buf.i32(value), |stream| stream.i32(value))
     }
 
+    #[inline]
     fn i64(&mut self, value: i64) -> sval::Result {
         self.value(|buf| buf.i64(value), |stream| stream.i64(value))
     }
 
+    #[inline]
     fn i128(&mut self, value: i128) -> sval::Result {
         self.value(|buf| buf.i128(value), |stream| stream.i128(value))
     }
 
+    #[inline]
     fn f32(&mut self, value: f32) -> sval::Result {
         self.value(|buf| buf.f32(value), |stream| stream.f32(value))
     }
 
+    #[inline]
     fn f64(&mut self, value: f64) -> sval::Result {
         self.value(|buf| buf.f64(value), |stream| stream.f64(value))
     }
 
+    #[inline]
     fn map_begin(&mut self, num_entries: Option<usize>) -> sval::Result {
         self.flattenable_begin(
             |buf| buf.map_begin(num_entries),
@@ -250,6 +280,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn map_key_begin(&mut self) -> sval::Result {
         self.flattenable_value(
             |buf| buf.map_key_begin(),
@@ -262,6 +293,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn map_key_end(&mut self) -> sval::Result {
         self.flattenable_value(
             |buf| buf.map_key_end(),
@@ -274,6 +306,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn map_value_begin(&mut self) -> sval::Result {
         self.flattenable_value(
             |buf| buf.map_value_begin(),
@@ -289,6 +322,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn map_value_end(&mut self) -> sval::Result {
         self.flattenable_value(
             |buf| buf.map_value_end(),
@@ -303,6 +337,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn map_end(&mut self) -> sval::Result {
         self.flattenable_end(
             |buf| buf.map_end(),
@@ -311,6 +346,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn seq_begin(&mut self, num_entries: Option<usize>) -> sval::Result {
         self.flattenable_begin(
             |buf| buf.seq_begin(num_entries),
@@ -319,6 +355,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn seq_value_begin(&mut self) -> sval::Result {
         self.flattenable_value(
             |buf| buf.seq_value_begin(),
@@ -333,6 +370,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn seq_value_end(&mut self) -> sval::Result {
         self.flattenable_value(
             |buf| buf.seq_value_end(),
@@ -347,6 +385,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn seq_end(&mut self) -> sval::Result {
         self.flattenable_end(
             |buf| buf.seq_end(),
@@ -355,6 +394,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn enum_begin(
         &mut self,
         tag: Option<&Tag>,
@@ -371,6 +411,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn enum_end(
         &mut self,
         tag: Option<&Tag>,
@@ -384,6 +425,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn tagged_begin(
         &mut self,
         tag: Option<&Tag>,
@@ -414,6 +456,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         }
     }
 
+    #[inline]
     fn tagged_end(
         &mut self,
         tag: Option<&Tag>,
@@ -442,6 +485,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         }
     }
 
+    #[inline]
     fn tag(
         &mut self,
         tag: Option<&Tag>,
@@ -454,6 +498,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_begin(
         &mut self,
         tag: Option<&Tag>,
@@ -468,6 +513,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_value_begin(&mut self, tag: Option<&Tag>, label: &Label) -> sval::Result {
         self.flattenable_value(
             |buf| buf.record_value_begin(tag, label),
@@ -478,6 +524,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_value_end(&mut self, tag: Option<&Tag>, label: &Label) -> sval::Result {
         self.flattenable_value(
             |buf| buf.record_value_end(tag, label),
@@ -488,6 +535,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_end(
         &mut self,
         tag: Option<&Tag>,
@@ -501,6 +549,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn tuple_begin(
         &mut self,
         tag: Option<&Tag>,
@@ -515,6 +564,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn tuple_value_begin(&mut self, tag: Option<&Tag>, index: &Index) -> sval::Result {
         self.flattenable_value(
             |buf| buf.tuple_value_begin(tag, index),
@@ -529,6 +579,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn tuple_value_end(&mut self, tag: Option<&Tag>, index: &Index) -> sval::Result {
         self.flattenable_value(
             |buf| buf.tuple_value_end(tag, index),
@@ -543,6 +594,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn tuple_end(
         &mut self,
         tag: Option<&Tag>,
@@ -556,6 +608,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_tuple_begin(
         &mut self,
         tag: Option<&Tag>,
@@ -570,6 +623,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_tuple_value_begin(
         &mut self,
         tag: Option<&Tag>,
@@ -585,6 +639,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_tuple_value_end(
         &mut self,
         tag: Option<&Tag>,
@@ -600,6 +655,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
         )
     }
 
+    #[inline]
     fn record_tuple_end(
         &mut self,
         tag: Option<&Tag>,
@@ -614,6 +670,7 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
     }
 }
 
+#[inline]
 fn with_index_to_label(
     index: &Index,
     label: Option<&Label>,

--- a/json/bench/Cargo.toml
+++ b/json/bench/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2021"
 [lib]
 path = "lib.rs"
 
-[dependencies.rustversion]
-version = "1"
-
 [dependencies.sval]
 path = "../../"
 features = ["std"]


### PR DESCRIPTION
Fairly small change, but reducing the impact of `flatten` as much as possible is worthwhile.

Before:

```
test flatten_60   ... bench:          19 ns/iter (+/- 0)
test unflatten_60 ... bench:           0 ns/iter (+/- 0)
```

After:

```
test flatten_60   ... bench:          15 ns/iter (+/- 2)
test unflatten_60 ... bench:           1 ns/iter (+/- 0)
```