### PR TITLE
Fix a bug with missing commas in JSON

### DIFF
--- a/fmt/test/lib.rs
+++ b/fmt/test/lib.rs
@@ -28,11 +28,29 @@ struct Number(&'static str);
 struct MapStruct {
     field_0: i32,
     field_1: bool,
-    field_2: &'static str,
+    field_2: EmptyMap,
+    field_3: &'static str,
+    field_4: &'static [i32],
+    field_5: u32,
+}
+
+struct EmptyMap {}
+
+impl fmt::Debug for EmptyMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().finish()
+    }
+}
+
+impl sval::Value for EmptyMap {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        stream.map_begin(Some(0))?;
+        stream.map_end()
+    }
 }
 
 #[derive(Value, Debug)]
-struct SeqStruct(i32, bool, &'static str);
+struct SeqStruct(i32, bool, EmptyMap, &'static str, &'static [i32], u32);
 
 #[derive(Value, Debug)]
 struct Tagged(i32);
@@ -44,9 +62,12 @@ enum Enum {
     MapStruct {
         field_0: i32,
         field_1: bool,
-        field_2: &'static str,
+        field_2: EmptyMap,
+        field_3: &'static str,
+        field_4: &'static [i32],
+        field_5: u32,
     },
-    SeqStruct(i32, bool, &'static str),
+    SeqStruct(i32, bool, EmptyMap, &'static str, &'static [i32], u32),
 }
 
 #[test]
@@ -72,13 +93,16 @@ fn debug_map_struct() {
     assert_fmt(MapStruct {
         field_0: 42,
         field_1: true,
-        field_2: "Hello",
+        field_2: EmptyMap {},
+        field_3: "Hello",
+        field_4: &[],
+        field_5: 17,
     });
 }
 
 #[test]
 fn debug_seq_struct() {
-    assert_fmt(SeqStruct(42, true, "Hello"));
+    assert_fmt(SeqStruct(42, true, EmptyMap {}, "Hello", &[], 17));
     assert_fmt((42, true, "Hello"));
 }
 
@@ -94,10 +118,13 @@ fn debug_enum() {
     assert_fmt(Enum::MapStruct {
         field_0: 42,
         field_1: true,
-        field_2: "Hello",
+        field_2: EmptyMap {},
+        field_3: "Hello",
+        field_4: &[],
+        field_5: 17,
     });
 
-    assert_fmt(Enum::SeqStruct(42, true, "Hello"));
+    assert_fmt(Enum::SeqStruct(42, true, EmptyMap {}, "Hello", &[], 17));
 
     assert_fmt(Enum::Tagged(42));
 }
@@ -308,13 +335,16 @@ fn stream_token_write_compact() {
         MapStruct {
             field_0: 42,
             field_1: true,
-            field_2: "text \"in quotes\"",
+            field_2: EmptyMap {},
+            field_3: "text \"in quotes\"",
+            field_4: &[],
+            field_5: 17,
         },
     )
     .unwrap();
 
     assert_eq!(
-        r#"MapStruct{field_0:42,field_1:true,field_2:"text \"in quotes\""}"#,
+        r#"MapStruct{field_0:42,field_1:true,field_2:{},field_3:"text \"in quotes\"",field_4:[],field_5:17}"#,
         buf
     );
 }
@@ -345,13 +375,16 @@ fn stream_token_write_no_escaping() {
         MapStruct {
             field_0: 42,
             field_1: true,
-            field_2: "text \"in quotes\"",
+            field_2: EmptyMap {},
+            field_3: "text \"in quotes\"",
+            field_4: &[],
+            field_5: 17,
         },
     )
     .unwrap();
 
     assert_eq!(
-        r#"MapStruct { field_0: 42, field_1: true, field_2: text "in quotes" }"#,
+        r#"MapStruct { field_0: 42, field_1: true, field_2: {}, field_3: text "in quotes", field_4: [], field_5: 17 }"#,
         buf
     );
 }
@@ -504,7 +537,10 @@ fn stream_token_write_indented() {
         MapStruct {
             field_0: 42,
             field_1: true,
-            field_2: "text \"in quotes\"",
+            field_2: EmptyMap {},
+            field_3: "text \"in quotes\"",
+            field_4: &[],
+            field_5: 17,
         },
     )
     .unwrap();
@@ -513,7 +549,10 @@ fn stream_token_write_indented() {
         r#"MapStruct {
     field_0: 42,
     field_1: true,
-    field_2: "text \"in quotes\"",
+    field_2: {},
+    field_3: "text \"in quotes\"",
+    field_4: [],
+    field_5: 17,
 }"#,
         buf
     );

--- a/json/bench/lib.rs
+++ b/json/bench/lib.rs
@@ -197,6 +197,14 @@ pub fn input_struct() -> Twitter {
     serde_json::from_str(&j).unwrap()
 }
 
+#[test]
+fn compat() {
+    let serde = serde_json::to_string(&input_struct()).unwrap();
+    let sval = sval_json::stream_to_string(input_struct()).unwrap();
+
+    assert_eq!(serde, sval);
+}
+
 #[bench]
 fn primitive_miniserde(b: &mut test::Bencher) {
     b.iter(|| miniserde::json::to_string(&42));

--- a/json/src/to_fmt.rs
+++ b/json/src/to_fmt.rs
@@ -221,6 +221,7 @@ where
     }
 
     fn map_end(&mut self) -> sval::Result {
+        self.is_current_depth_empty = false;
         _try!(self.out.write_char('}'));
 
         Ok(())
@@ -255,6 +256,7 @@ where
     }
 
     fn seq_end(&mut self) -> sval::Result {
+        self.is_current_depth_empty = false;
         _try!(self.out.write_char(']'));
 
         Ok(())

--- a/json/test/lib.rs
+++ b/json/test/lib.rs
@@ -41,6 +41,15 @@ struct MapStruct<F0, F1> {
 struct SeqStruct<F0, F1>(F0, F1);
 
 #[derive(Value, Serialize)]
+struct NestedMap {
+    field_0: i32,
+    field_1: bool,
+}
+
+#[derive(Value, Serialize)]
+struct EmptyMap {}
+
+#[derive(Value, Serialize)]
 struct Tagged<T>(T);
 
 #[derive(Clone, Value, Serialize)]
@@ -154,6 +163,27 @@ fn stream_map_struct() {
         field_0: "Hello",
         field_1: 1.3,
     });
+
+    assert_json(MapStruct {
+        field_0: EmptyMap {},
+        field_1: EmptyMap {},
+    });
+
+    assert_json(MapStruct {
+        field_0: &[] as &[i32],
+        field_1: &[] as &[i32],
+    });
+
+    assert_json(MapStruct {
+        field_0: NestedMap {
+            field_0: 42,
+            field_1: true,
+        },
+        field_1: NestedMap {
+            field_0: 43,
+            field_1: false,
+        },
+    });
 }
 
 #[test]
@@ -161,6 +191,27 @@ fn stream_seq_struct() {
     assert_json(SeqStruct(42, true));
     assert_json(SeqStruct("Hello", 1.3));
     assert_json((42, true));
+
+    #[derive(Value, Serialize)]
+    struct NestedMap {
+        field_0: i32,
+        field_1: bool,
+    }
+
+    assert_json((
+        NestedMap {
+            field_0: 42,
+            field_1: true,
+        },
+        NestedMap {
+            field_0: 43,
+            field_1: false,
+        },
+    ));
+
+    assert_json((EmptyMap {}, EmptyMap {}));
+
+    assert_json((&[] as &[i32], &[] as &[i32]));
 }
 
 #[test]

--- a/json/test/lib.rs
+++ b/json/test/lib.rs
@@ -57,7 +57,9 @@ enum Enum<F0, F1> {
     Constant,
     Tagged(F0),
     MapStruct { field_0: F0, field_1: F1 },
+    EmptyMapStruct,
     SeqStruct(F0, F1),
+    EmptySeq(&'static [i32]),
     Nested(Box<Enum<F0, F1>>),
 }
 
@@ -227,7 +229,9 @@ fn stream_enum() {
             field_0: 42,
             field_1: true,
         },
+        Enum::EmptyMapStruct,
         Enum::SeqStruct(42, true),
+        Enum::EmptySeq(&[]),
         Enum::Tagged(42),
     ] {
         assert_json(&variant);


### PR DESCRIPTION
When writing empty maps or sequences as fields we were missing a comma between it and a subsequent value.