### PR TITLE
Fix a panic attempting to buffer an invalid value

### DIFF
--- a/json/bench/lib.rs
+++ b/json/bench/lib.rs
@@ -286,7 +286,12 @@ fn twitter_sval_collect(b: &mut test::Bencher) {
 #[bench]
 fn twitter_sval_collect_owned(b: &mut test::Bencher) {
     let s = input_struct();
-    b.iter(|| sval_buffer::Value::collect(&s).unwrap().into_owned().unwrap());
+    b.iter(|| {
+        sval_buffer::Value::collect(&s)
+            .unwrap()
+            .into_owned()
+            .unwrap()
+    });
 }
 
 #[bench]


### PR DESCRIPTION
Implementations of `Value` aren't supposed to error on their own, but they technically can, so we ensure we don't panic if that happens while buffering.