### PR TITLE
Fix buffering in new nested crate

### DIFF
--- a/json/bench/Cargo.toml
+++ b/json/bench/Cargo.toml
@@ -40,7 +40,7 @@ version = "1"
 version = "1"
 
 [dependencies.erased-serde]
-version = "0.3"
+version = "0.4"
 
 [dependencies.miniserde]
 version = "0.1"

--- a/json/bench/Cargo.toml
+++ b/json/bench/Cargo.toml
@@ -28,7 +28,7 @@ features = ["std"]
 
 [dependencies.sval_serde]
 path = "../../serde"
-features = ["std"]
+default-features = false
 
 [dependencies.serde]
 version = "1"

--- a/nested/src/flat.rs
+++ b/nested/src/flat.rs
@@ -178,7 +178,7 @@ impl<'sval, S: Stream<'sval>> FlatStream<'sval, S> {
 impl<'sval, S: Stream<'sval>> sval::Stream<'sval> for FlatStream<'sval, S> {
     fn value<V: sval::Value + ?Sized>(&mut self, v: &'sval V) -> sval::Result {
         self.buffer_or_stream_with(
-            |buf| buf.value(v),
+            |buf| sval::Stream::value(buf, v),
             |stream| match stream.state {
                 State::Enum(_) => {
                     sval::default_stream::value(stream, v)
@@ -192,7 +192,7 @@ impl<'sval, S: Stream<'sval>> sval::Stream<'sval> for FlatStream<'sval, S> {
 
     fn value_computed<V: sval::Value + ?Sized>(&mut self, v: &V) -> sval::Result {
         self.buffer_or_stream_with(
-            |buf| buf.value_computed(v),
+            |buf| sval::Stream::value_computed(buf, v),
             |stream| match stream.state {
                 State::Enum(_) => {
                     sval::default_stream::value_computed(stream, v)

--- a/serde/src/to_serialize.rs
+++ b/serde/src/to_serialize.rs
@@ -42,7 +42,7 @@ impl<V: sval::Value + ?Sized> ToSerialize<V> {
 impl<V: sval::Value> serde::Serialize for ToSerialize<V> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         Serializer::new(serializer)
-            .value_computed(&self.0)
+            .value_ref(&self.0)
             .unwrap_or_else(|e| Err(S::Error::custom(e)))
     }
 }
@@ -180,7 +180,9 @@ impl<'sval, S: serde::Serializer> Stream<'sval> for Serializer<S> {
             _ => {
                 let name = label
                     .and_then(|label| label.as_static_str())
-                    .ok_or_else(|| sval_nested::Error::invalid_value("unit label must be static"))?;
+                    .ok_or_else(|| {
+                        sval_nested::Error::invalid_value("unit label must be static")
+                    })?;
 
                 Ok(self.serializer.serialize_unit_struct(name))
             }
@@ -201,7 +203,9 @@ impl<'sval, S: serde::Serializer> Stream<'sval> for Serializer<S> {
             _ => {
                 let name = label
                     .and_then(|label| label.as_static_str())
-                    .ok_or_else(|| sval_nested::Error::invalid_value("newtype label must be static"))?;
+                    .ok_or_else(|| {
+                        sval_nested::Error::invalid_value("newtype label must be static")
+                    })?;
 
                 Ok(self
                     .serializer
@@ -234,9 +238,9 @@ impl<'sval, S: serde::Serializer> Stream<'sval> for Serializer<S> {
 
         match label {
             Some(label) => {
-                let name = label
-                    .as_static_str()
-                    .ok_or_else(|| sval_nested::Error::invalid_value("tuple label must be static"))?;
+                let name = label.as_static_str().ok_or_else(|| {
+                    sval_nested::Error::invalid_value("tuple label must be static")
+                })?;
 
                 Ok(SerializeTuple {
                     serializer: self
@@ -266,9 +270,9 @@ impl<'sval, S: serde::Serializer> Stream<'sval> for Serializer<S> {
 
         match label {
             Some(label) => {
-                let name = label
-                    .as_static_str()
-                    .ok_or_else(|| sval_nested::Error::invalid_value("struct label must be static"))?;
+                let name = label.as_static_str().ok_or_else(|| {
+                    sval_nested::Error::invalid_value("struct label must be static")
+                })?;
 
                 Ok(SerializeRecord {
                     serializer: self
@@ -491,11 +495,13 @@ impl<'sval, S: serde::Serializer> StreamEnum<'sval> for SerializeEnum<S> {
     ) -> sval_nested::Result<Self::Ok> {
         let variant = label
             .and_then(|label| label.as_static_str())
-            .ok_or_else(|| sval_nested::Error::invalid_value("unit variant label must be static"))?;
+            .ok_or_else(|| {
+                sval_nested::Error::invalid_value("unit variant label must be static")
+            })?;
 
-        let variant_index = index
-            .and_then(|index| index.to_u32())
-            .ok_or_else(|| sval_nested::Error::invalid_value("unit variant index must a 32bit value"))?;
+        let variant_index = index.and_then(|index| index.to_u32()).ok_or_else(|| {
+            sval_nested::Error::invalid_value("unit variant index must a 32bit value")
+        })?;
 
         Ok(self
             .serializer
@@ -511,11 +517,13 @@ impl<'sval, S: serde::Serializer> StreamEnum<'sval> for SerializeEnum<S> {
     ) -> sval_nested::Result<Self::Ok> {
         let variant = label
             .and_then(|label| label.as_static_str())
-            .ok_or_else(|| sval_nested::Error::invalid_value("newtype variant label must be static"))?;
+            .ok_or_else(|| {
+                sval_nested::Error::invalid_value("newtype variant label must be static")
+            })?;
 
-        let variant_index = index
-            .and_then(|index| index.to_u32())
-            .ok_or_else(|| sval_nested::Error::invalid_value("newtype variant index must be a 32bit value"))?;
+        let variant_index = index.and_then(|index| index.to_u32()).ok_or_else(|| {
+            sval_nested::Error::invalid_value("newtype variant index must be a 32bit value")
+        })?;
 
         Ok(self.serializer.serialize_newtype_variant(
             self.name,
@@ -534,14 +542,16 @@ impl<'sval, S: serde::Serializer> StreamEnum<'sval> for SerializeEnum<S> {
     ) -> sval_nested::Result<Self::Tuple> {
         let variant = label
             .and_then(|label| label.as_static_str())
-            .ok_or_else(|| sval_nested::Error::invalid_value("tuple variant label must be static"))?;
+            .ok_or_else(|| {
+                sval_nested::Error::invalid_value("tuple variant label must be static")
+            })?;
 
-        let variant_index = index
-            .and_then(|index| index.to_u32())
-            .ok_or_else(|| sval_nested::Error::invalid_value("tuple variant index must be a 32bit value"))?;
+        let variant_index = index.and_then(|index| index.to_u32()).ok_or_else(|| {
+            sval_nested::Error::invalid_value("tuple variant index must be a 32bit value")
+        })?;
 
-        let len =
-            num_entries.ok_or_else(|| sval_nested::Error::invalid_value("missing tuple variant len"))?;
+        let len = num_entries
+            .ok_or_else(|| sval_nested::Error::invalid_value("missing tuple variant len"))?;
 
         Ok(SerializeTupleVariant {
             serializer: self.serializer.serialize_tuple_variant(
@@ -562,14 +572,16 @@ impl<'sval, S: serde::Serializer> StreamEnum<'sval> for SerializeEnum<S> {
     ) -> sval_nested::Result<Self::Record> {
         let variant = label
             .and_then(|label| label.as_static_str())
-            .ok_or_else(|| sval_nested::Error::invalid_value("struct variant label must be static"))?;
+            .ok_or_else(|| {
+                sval_nested::Error::invalid_value("struct variant label must be static")
+            })?;
 
-        let variant_index = index
-            .and_then(|index| index.to_u32())
-            .ok_or_else(|| sval_nested::Error::invalid_value("struct variant index must be a 32bit value"))?;
+        let variant_index = index.and_then(|index| index.to_u32()).ok_or_else(|| {
+            sval_nested::Error::invalid_value("struct variant index must be a 32bit value")
+        })?;
 
-        let len =
-            num_entries.ok_or_else(|| sval_nested::Error::invalid_value("missing struct variant len"))?;
+        let len = num_entries
+            .ok_or_else(|| sval_nested::Error::invalid_value("missing struct variant len"))?;
 
         Ok(SerializeRecordVariant {
             serializer: self.serializer.serialize_struct_variant(
@@ -611,9 +623,9 @@ impl<'sval, S: serde::ser::SerializeStructVariant> StreamRecord<'sval>
         label: sval::Label,
         value: V,
     ) -> sval_nested::Result {
-        let field = label
-            .as_static_str()
-            .ok_or_else(|| sval_nested::Error::invalid_value("struct variant field label must be static"))?;
+        let field = label.as_static_str().ok_or_else(|| {
+            sval_nested::Error::invalid_value("struct variant field label must be static")
+        })?;
 
         if let Ok(ref mut serializer) = self.serializer {
             match serializer.serialize_field(field, &ToSerialize::new(value)) {

--- a/src/data/seq.rs
+++ b/src/data/seq.rs
@@ -17,15 +17,7 @@ impl<T: Value> Value for [T] {
 impl<T: Value, const N: usize> Value for [T; N] {
     fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
         stream.tagged_begin(Some(&tags::CONSTANT_SIZE), None, None)?;
-        stream.seq_begin(Some(self.len()))?;
-
-        for elem in self {
-            stream.seq_value_begin()?;
-            stream.value(elem)?;
-            stream.seq_value_end()?;
-        }
-
-        stream.seq_end()?;
+        stream.value(self as &'a [T])?;
         stream.tagged_end(Some(&tags::CONSTANT_SIZE), None, None)
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -781,6 +781,11 @@ impl<S: ?Sized> Computed<S> {
 
 impl<'a, 'b, S: Stream<'a> + ?Sized> Stream<'b> for Computed<S> {
     #[inline]
+    fn value<V: Value + ?Sized>(&mut self, v: &'b V) -> Result {
+        default_stream::value(self, v)
+    }
+
+    #[inline]
     fn value_computed<V: Value + ?Sized>(&mut self, v: &V) -> Result {
         self.0.value_computed(v)
     }


### PR DESCRIPTION
The new (unreleased) `sval_nested` crate regressed performance pretty badly because it was always buffering computed values. This should be fixed up now. I'll still run some comparison benches between `main` and what's currently released for `sval_serde` to make sure it's still in the same ballpark.