### PR TITLE
nested: fix compiling tests with Rust < 1.74

### DIFF
--- a/nested/src/lib.rs
+++ b/nested/src/lib.rs
@@ -1747,7 +1747,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn stream_binary_owned() {
         assert_eq!(
-            Value::Binary(Cow::Owned(b"owned".into())),
+            Value::Binary(Cow::Owned(b"owned".to_vec())),
             ToValue::default()
                 .value_ref(&{
                     struct Binary;


### PR DESCRIPTION
The `From` implementation that this code relies on was only stabilized in Rust 1.74. Changing the `.into()` call to `.to_vec()` is equivalent but works on all recent versions of Rust.

```
error[E0277]: the trait bound `Vec<u8>: From<&[u8; 5]>` is not satisfied
    --> nested/src/lib.rs:1750:38
     |
1750 |             Value::Binary(Cow::Owned(b"owned".into())),
     |                                      ^^^^^^^^ ---- required by a bound introduced by this call
     |                                      |
     |                                      the trait `From<&[u8; 5]>` is not implemented for `Vec<u8>`
     |
     = note: required for `&[u8; 5]` to implement `Into<Vec<u8>>`
help: consider dereferencing here
     |
1750 |             Value::Binary(Cow::Owned(*b"owned".into())),
     |                                      +
```

c.f. https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html#stabilized-apis