### PR TITLE
Fix warnings and fallback to indexes as tags when labels are missing

### DIFF
--- a/derive/test/compile_fail/enum_dynamic_unindexed_variants.rs
+++ b/derive/test/compile_fail/enum_dynamic_unindexed_variants.rs
@@ -1,0 +1,13 @@
+use sval_derive::*;
+
+#[derive(Value)]
+#[sval(dynamic, unindexed_variants)]
+pub enum Enum {
+    A,
+    B,
+    C,
+}
+
+fn main() {
+
+}

--- a/derive/test/compile_fail/enum_dynamic_unindexed_variants.stderr
+++ b/derive/test/compile_fail/enum_dynamic_unindexed_variants.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> compile_fail/enum_dynamic_unindexed_variants.rs:3:10
+  |
+3 | #[derive(Value)]
+  |          ^^^^^
+  |
+  = help: message: dynamic enums don't have variants

--- a/derive/test/compile_fail/enum_dynamic_unlabeled_variants.rs
+++ b/derive/test/compile_fail/enum_dynamic_unlabeled_variants.rs
@@ -1,0 +1,13 @@
+use sval_derive::*;
+
+#[derive(Value)]
+#[sval(dynamic, unlabeled_variants)]
+pub enum Enum {
+    A,
+    B,
+    C,
+}
+
+fn main() {
+
+}

--- a/derive/test/compile_fail/enum_dynamic_unlabeled_variants.stderr
+++ b/derive/test/compile_fail/enum_dynamic_unlabeled_variants.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> compile_fail/enum_dynamic_unlabeled_variants.rs:3:10
+  |
+3 | #[derive(Value)]
+  |          ^^^^^
+  |
+  = help: message: dynamic enums don't have variants

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -707,6 +707,201 @@ mod derive_enum {
     }
 
     #[test]
+    fn unlabeled() {
+        #[derive(Value)]
+        #[sval(unlabeled_variants)]
+        enum Enum {
+            Tag,
+            Tagged(i32),
+            Record { a: i32 },
+            Tuple(i32, i32),
+        }
+
+        assert_tokens(&Enum::Tag, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                Tag(None, None, Some(sval::Index::new(0))),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Tagged(42), {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                TaggedBegin(None, None, Some(sval::Index::new(1))),
+                I32(42),
+                TaggedEnd(None, None, Some(sval::Index::new(1))),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Record { a: 42 }, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                RecordTupleBegin(None, None, Some(sval::Index::new(2)), Some(1)),
+                RecordTupleValueBegin(None, sval::Label::new("a"), sval::Index::new(0)),
+                I32(42),
+                RecordTupleValueEnd(None, sval::Label::new("a"), sval::Index::new(0)),
+                RecordTupleEnd(None, None, Some(sval::Index::new(2))),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Tuple(42, 43), {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                TupleBegin(None, None, Some(sval::Index::new(3)), Some(2)),
+                TupleValueBegin(None, sval::Index::new(0)),
+                I32(42),
+                TupleValueEnd(None, sval::Index::new(0)),
+                TupleValueBegin(None, sval::Index::new(1)),
+                I32(43),
+                TupleValueEnd(None, sval::Index::new(1)),
+                TupleEnd(None, None, Some(sval::Index::new(3))),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+    }
+
+    #[test]
+    fn unindexed() {
+        #[derive(Value)]
+        #[sval(unindexed_variants)]
+        enum Enum {
+            Tag,
+            Tagged(i32),
+            Record { a: i32 },
+            Tuple(i32, i32),
+        }
+
+        assert_tokens(&Enum::Tag, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                Tag(None, Some(sval::Label::new("Tag")), None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Tagged(42), {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                TaggedBegin(None, Some(sval::Label::new("Tagged")), None),
+                I32(42),
+                TaggedEnd(None, Some(sval::Label::new("Tagged")), None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Record { a: 42 }, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                RecordTupleBegin(None, Some(sval::Label::new("Record")), None, Some(1)),
+                RecordTupleValueBegin(None, sval::Label::new("a"), sval::Index::new(0)),
+                I32(42),
+                RecordTupleValueEnd(None, sval::Label::new("a"), sval::Index::new(0)),
+                RecordTupleEnd(None, Some(sval::Label::new("Record")), None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Tuple(42, 43), {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                TupleBegin(None, Some(sval::Label::new("Tuple")), None, Some(2)),
+                TupleValueBegin(None, sval::Index::new(0)),
+                I32(42),
+                TupleValueEnd(None, sval::Index::new(0)),
+                TupleValueBegin(None, sval::Index::new(1)),
+                I32(43),
+                TupleValueEnd(None, sval::Index::new(1)),
+                TupleEnd(None, Some(sval::Label::new("Tuple")), None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+    }
+
+    #[test]
+    fn unlabeled_unindexed() {
+        #[derive(Value)]
+        #[sval(unlabeled_variants, unindexed_variants)]
+        enum Enum {
+            Tag,
+            Tagged(i32),
+            Record { a: i32 },
+            Tuple(i32, i32),
+        }
+
+        assert_tokens(&Enum::Tag, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                Tag(None, None, None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Tagged(42), {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                TaggedBegin(None, None, None),
+                I32(42),
+                TaggedEnd(None, None, None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Record { a: 42 }, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                RecordTupleBegin(None, None, None, Some(1)),
+                RecordTupleValueBegin(None, sval::Label::new("a"), sval::Index::new(0)),
+                I32(42),
+                RecordTupleValueEnd(None, sval::Label::new("a"), sval::Index::new(0)),
+                RecordTupleEnd(None, None, None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+
+        assert_tokens(&Enum::Tuple(42, 43), {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                TupleBegin(None, None, None, Some(2)),
+                TupleValueBegin(None, sval::Index::new(0)),
+                I32(42),
+                TupleValueEnd(None, sval::Index::new(0)),
+                TupleValueBegin(None, sval::Index::new(1)),
+                I32(43),
+                TupleValueEnd(None, sval::Index::new(1)),
+                TupleEnd(None, None, None),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+    }
+
+    #[test]
     fn tagged() {
         const CONTAINER: sval::Tag = sval::Tag::new("container");
         const VARIANT: sval::Tag = sval::Tag::new("variant");

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -235,6 +235,56 @@ impl RawAttribute for UnindexedFieldsAttr {
 }
 
 /**
+The `unlabeled_variants` attribute.
+
+This attribute signals that all variants should be unlabeled.
+*/
+pub(crate) struct UnlabeledVariantsAttr;
+
+impl SvalAttribute for UnlabeledVariantsAttr {
+    type Result = bool;
+
+    fn from_lit(&self, lit: &Lit) -> Self::Result {
+        if let Lit::Bool(ref b) = lit {
+            b.value
+        } else {
+            panic!("unexpected value")
+        }
+    }
+}
+
+impl RawAttribute for UnlabeledVariantsAttr {
+    fn key(&self) -> &str {
+        "unlabeled_variants"
+    }
+}
+
+/**
+The `unindexed_variants` attribute.
+
+This attribute signals that all variants should be unindexed.
+*/
+pub(crate) struct UnindexedVariantsAttr;
+
+impl SvalAttribute for UnindexedVariantsAttr {
+    type Result = bool;
+
+    fn from_lit(&self, lit: &Lit) -> Self::Result {
+        if let Lit::Bool(ref b) = lit {
+            b.value
+        } else {
+            panic!("unexpected value")
+        }
+    }
+}
+
+impl RawAttribute for UnindexedVariantsAttr {
+    fn key(&self) -> &str {
+        "unindexed_variants"
+    }
+}
+
+/**
 The `dynamic` attribute.
 
 This attribute signals that an enum should be dynamic.

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -50,6 +50,9 @@ impl EnumAttrs {
             assert!(tag.is_none(), "dynamic enums can't have tags");
             assert!(label.is_none(), "dynamic enums can't have labels");
             assert!(index.is_none(), "dynamic enums can't have indexes");
+
+            assert!(!unlabeled_variants, "dynamic enums don't have variants");
+            assert!(!unindexed_variants, "dynamic enums don't have variants");
         }
 
         EnumAttrs {

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -40,8 +40,10 @@ impl EnumAttrs {
         let tag = attr::get_unchecked("enum", attr::TagAttr, attrs);
         let label = attr::get_unchecked("enum", attr::LabelAttr, attrs);
         let index = attr::get_unchecked("enum", attr::IndexAttr, attrs);
-        let unlabeled_variants = attr::get_unchecked("enum", attr::UnlabeledVariantsAttr, attrs).unwrap_or(false);
-        let unindexed_variants = attr::get_unchecked("enum", attr::UnindexedVariantsAttr, attrs).unwrap_or(false);
+        let unlabeled_variants =
+            attr::get_unchecked("enum", attr::UnlabeledVariantsAttr, attrs).unwrap_or(false);
+        let unindexed_variants =
+            attr::get_unchecked("enum", attr::UnindexedVariantsAttr, attrs).unwrap_or(false);
         let dynamic = attr::get_unchecked("enum", attr::DynamicAttr, attrs).unwrap_or(false);
 
         if dynamic {

--- a/flatten/bench/lib.rs
+++ b/flatten/bench/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(test)]
 #![feature(test)]
 
 extern crate test;

--- a/json/src/to_fmt.rs
+++ b/json/src/to_fmt.rs
@@ -359,7 +359,7 @@ where
         &mut self,
         tag: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
     ) -> sval::Result {
         self.is_internally_tagged = false;
         self.is_current_depth_empty = false;
@@ -369,6 +369,8 @@ where
             _ => {
                 if let Some(label) = label {
                     self.value(label.as_str())
+                } else if let Some(index) = index.and_then(|ix| ix.to_i64()) {
+                    self.value(&index)
                 } else {
                     self.null()
                 }
@@ -674,14 +676,3 @@ static ESCAPE: [u8; 256] = [
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, // E
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, // F
 ];
-
-struct Escape<W>(W);
-
-impl<W> Write for Escape<W>
-where
-    W: Write,
-{
-    fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
-        escape_str(s, &mut self.0)
-    }
-}

--- a/json/src/to_fmt.rs
+++ b/json/src/to_fmt.rs
@@ -61,19 +61,37 @@ impl<W> Formatter<W> {
     }
 }
 
+impl<W> fmt::Debug for Formatter<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Formatter")
+            .field("is_internally_tagged", &self.is_internally_tagged)
+            .field("is_current_depth_empty", &self.is_current_depth_empty)
+            .field("is_text_quoted", &self.is_text_quoted)
+            .field("err", &self.err)
+            .field("text_handler", &self.text_handler.as_ref().map(|_| ()))
+            .finish()
+    }
+}
+
 impl<'sval, W> sval::Stream<'sval> for Formatter<W>
 where
     W: Write,
 {
     fn null(&mut self) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         Ok(_try!(self.out.write_str("null")))
     }
 
     fn bool(&mut self, v: bool) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         Ok(_try!(self.out.write_str(if v { "true" } else { "false" })))
     }
 
     fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         if self.is_text_quoted {
             _try!(self.out.write_char('"'));
         }
@@ -99,66 +117,88 @@ where
     }
 
     fn u8(&mut self, v: u8) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn u16(&mut self, v: u16) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn u32(&mut self, v: u32) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn u64(&mut self, v: u64) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn u128(&mut self, v: u128) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn i8(&mut self, v: i8) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn i16(&mut self, v: i16) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn i32(&mut self, v: i32) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn i64(&mut self, v: i64) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn i128(&mut self, v: i128) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         _try!(self.out.write_str(itoa::Buffer::new().format(v)));
 
         Ok(())
     }
 
     fn f32(&mut self, v: f32) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         if v.is_nan() || v.is_infinite() {
             self.null()
         } else {
@@ -169,6 +209,8 @@ where
     }
 
     fn f64(&mut self, v: f64) -> sval::Result {
+        self.is_current_depth_empty = false;
+
         if v.is_nan() || v.is_infinite() {
             self.null()
         } else {
@@ -197,7 +239,6 @@ where
         if !self.is_current_depth_empty {
             _try!(self.out.write_str(",\""));
         } else {
-            self.is_current_depth_empty = false;
             _try!(self.out.write_char('"'));
         }
 
@@ -244,8 +285,6 @@ where
 
         if !self.is_current_depth_empty {
             _try!(self.out.write_char(','));
-        } else {
-            self.is_current_depth_empty = false;
         }
 
         Ok(())
@@ -266,9 +305,9 @@ where
         &mut self,
         _: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
     ) -> sval::Result {
-        _try_no_conv!(self.internally_tagged_begin(label));
+        _try_no_conv!(self.internally_tagged_begin(label, index));
 
         self.is_internally_tagged = true;
         self.is_current_depth_empty = true;
@@ -289,7 +328,7 @@ where
         if self.is_internally_tagged {
             self.internally_tagged_map_end()
         } else {
-            self.internally_tagged_end(label)
+            self.internally_tagged_end(label, index)
         }
     }
 
@@ -297,7 +336,7 @@ where
         &mut self,
         tag: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
     ) -> sval::Result {
         match tag {
             Some(&tags::JSON_TEXT) => {
@@ -321,14 +360,17 @@ where
             _ => (),
         }
 
-        self.internally_tagged_begin(label)
+        _try_no_conv!(self.internally_tagged_begin(label, index));
+        self.is_current_depth_empty = true;
+
+        Ok(())
     }
 
     fn tagged_end(
         &mut self,
         tag: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
     ) -> sval::Result {
         match tag {
             Some(&tags::JSON_TEXT) => {
@@ -352,7 +394,11 @@ where
             _ => (),
         }
 
-        self.internally_tagged_end(label)
+        if self.is_current_depth_empty {
+            _try_no_conv!(self.tag(tag, label, index));
+        }
+
+        self.internally_tagged_end(label, index)
     }
 
     fn tag(
@@ -382,10 +428,10 @@ where
         &mut self,
         _: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
         num_entries_hint: Option<usize>,
     ) -> sval::Result {
-        _try_no_conv!(self.internally_tagged_begin(label));
+        _try_no_conv!(self.internally_tagged_begin(label, index));
         self.map_begin(num_entries_hint)
     }
 
@@ -395,7 +441,6 @@ where
         if !self.is_current_depth_empty {
             _try!(self.out.write_str(",\""));
         } else {
-            self.is_current_depth_empty = false;
             _try!(self.out.write_char('"'));
         }
 
@@ -415,20 +460,20 @@ where
         &mut self,
         _: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
     ) -> sval::Result {
         _try_no_conv!(self.map_end());
-        self.internally_tagged_end(label)
+        self.internally_tagged_end(label, index)
     }
 
     fn tuple_begin(
         &mut self,
         _: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
         num_entries_hint: Option<usize>,
     ) -> sval::Result {
-        _try_no_conv!(self.internally_tagged_begin(label));
+        _try_no_conv!(self.internally_tagged_begin(label, index));
         self.seq_begin(num_entries_hint)
     }
 
@@ -436,10 +481,10 @@ where
         &mut self,
         _: Option<&sval::Tag>,
         label: Option<&sval::Label>,
-        _: Option<&sval::Index>,
+        index: Option<&sval::Index>,
     ) -> sval::Result {
         _try_no_conv!(self.seq_end());
-        self.internally_tagged_end(label)
+        self.internally_tagged_end(label, index)
     }
 }
 
@@ -447,33 +492,51 @@ impl<'sval, W> Formatter<W>
 where
     W: Write,
 {
-    fn internally_tagged_begin(&mut self, label: Option<&sval::Label>) -> sval::Result {
+    fn internally_tagged_begin(
+        &mut self,
+        label: Option<&sval::Label>,
+        index: Option<&sval::Index>,
+    ) -> sval::Result {
         // If there's a label then begin a map, using the label as the key
         if self.is_internally_tagged {
-            self.is_current_depth_empty = false;
             self.is_internally_tagged = false;
 
             if let Some(label) = label {
-                return self.internally_tagged_map_begin(label);
+                return self.internally_tagged_map_begin_label(label.as_str());
+            } else if let Some(index) = index.and_then(|index| index.to_i64()) {
+                return self.internally_tagged_map_begin_index(index);
             }
         }
 
         Ok(())
     }
 
-    fn internally_tagged_end(&mut self, label: Option<&sval::Label>) -> sval::Result {
-        if label.is_some() {
-            self.is_internally_tagged = true;
-        }
+    fn internally_tagged_end(
+        &mut self,
+        label: Option<&sval::Label>,
+        index: Option<&sval::Index>,
+    ) -> sval::Result {
+        self.is_internally_tagged =
+            label.is_some() || index.and_then(|index| index.to_i64()).is_some();
 
         Ok(())
     }
 
-    fn internally_tagged_map_begin(&mut self, label: &sval::Label) -> sval::Result {
+    fn internally_tagged_map_begin_label(&mut self, label: &str) -> sval::Result {
         _try_no_conv!(self.map_begin(Some(1)));
 
         _try_no_conv!(self.map_key_begin());
-        _try!(escape_str(label.as_str(), &mut self.out));
+        _try!(escape_str(label, &mut self.out));
+        _try_no_conv!(self.map_key_end());
+
+        self.map_value_begin()
+    }
+
+    fn internally_tagged_map_begin_index(&mut self, index: i64) -> sval::Result {
+        _try_no_conv!(self.map_begin(Some(1)));
+
+        _try_no_conv!(self.map_key_begin());
+        _try_no_conv!(self.i64(index));
         _try_no_conv!(self.map_key_end());
 
         self.map_value_begin()

--- a/json/test/lib.rs
+++ b/json/test/lib.rs
@@ -46,7 +46,7 @@ struct NestedMap {
     field_1: bool,
 }
 
-#[derive(Value, Serialize)]
+#[derive(Clone, Value, Serialize)]
 struct EmptyMap {}
 
 #[derive(Value, Serialize)]
@@ -60,10 +60,45 @@ enum Enum<F0, F1> {
     Constant,
     Tagged(F0),
     MapStruct { field_0: F0, field_1: F1 },
-    EmptyMapStruct,
+    EmptyMapStruct(EmptyMap),
     SeqStruct(F0, F1),
     EmptySeq(&'static [i32]),
     Nested(Box<Enum<F0, F1>>),
+}
+
+#[derive(Clone, Value)]
+#[sval(unlabeled_variants)]
+enum UnlabeledEnum<F0, F1> {
+    Constant,
+    Tagged(F0),
+    MapStruct { field_0: F0, field_1: F1 },
+    EmptyMapStruct(EmptyMap),
+    SeqStruct(F0, F1),
+    EmptySeq(&'static [i32]),
+    Nested(Box<UnlabeledEnum<F0, F1>>),
+}
+
+#[derive(Clone, Value)]
+#[sval(unlabeled_variants, unindexed_variants)]
+enum UnlabeledUnindexedEnum<F0, F1> {
+    Constant,
+    Tagged(F0),
+    MapStruct { field_0: F0, field_1: F1 },
+    EmptyMapStruct(EmptyMap),
+    SeqStruct(F0, F1),
+    EmptySeq(&'static [i32]),
+    Nested(Box<UnlabeledUnindexedEnum<F0, F1>>),
+}
+
+#[derive(Value)]
+#[sval(dynamic)]
+enum DynamicEnum<'a> {
+    Constant,
+    Null(sval::Null),
+    Text(&'a str),
+    Number(f64),
+    Boolean(bool),
+    Array(&'a [DynamicEnum<'a>]),
 }
 
 #[derive(Value)]
@@ -239,7 +274,7 @@ fn stream_enum() {
             field_0: 42,
             field_1: true,
         },
-        Enum::EmptyMapStruct,
+        Enum::EmptyMapStruct(EmptyMap {}),
         Enum::SeqStruct(42, true),
         Enum::EmptySeq(&[]),
         Enum::Tagged(42),
@@ -255,44 +290,122 @@ fn stream_enum() {
 }
 
 #[test]
-fn stream_untagged_enum() {
-    #[derive(Value)]
-    #[sval(dynamic)]
-    enum Dynamic<'a> {
-        Constant,
-        Null(sval::Null),
-        Text(&'a str),
-        Number(f64),
-        Boolean(bool),
-        Array(&'a [Dynamic<'a>]),
-    }
-
+fn stream_dynamic_enum() {
     assert_eq!(
         "\"Constant\"",
-        sval_json::stream_to_string(Dynamic::Constant).unwrap()
+        sval_json::stream_to_string(DynamicEnum::Constant).unwrap()
     );
     assert_eq!(
         "\"Some text\"",
-        sval_json::stream_to_string(Dynamic::Text("Some text")).unwrap()
+        sval_json::stream_to_string(DynamicEnum::Text("Some text")).unwrap()
     );
     assert_eq!(
         "3.14",
-        sval_json::stream_to_string(Dynamic::Number(3.14)).unwrap()
+        sval_json::stream_to_string(DynamicEnum::Number(3.14)).unwrap()
     );
     assert_eq!(
         "true",
-        sval_json::stream_to_string(Dynamic::Boolean(true)).unwrap()
+        sval_json::stream_to_string(DynamicEnum::Boolean(true)).unwrap()
     );
     assert_eq!(
         "null",
-        sval_json::stream_to_string(Dynamic::Null(sval::Null)).unwrap()
+        sval_json::stream_to_string(DynamicEnum::Null(sval::Null)).unwrap()
     );
     assert_eq!(
         "[true,false]",
-        sval_json::stream_to_string(Dynamic::Array(&[
-            Dynamic::Boolean(true),
-            Dynamic::Boolean(false),
+        sval_json::stream_to_string(DynamicEnum::Array(&[
+            DynamicEnum::Boolean(true),
+            DynamicEnum::Boolean(false),
         ]))
+        .unwrap()
+    );
+}
+
+#[test]
+fn stream_unlabeled_enum() {
+    assert_eq!(
+        "0",
+        sval_json::stream_to_string(UnlabeledEnum::<i32, bool>::Constant).unwrap()
+    );
+    assert_eq!(
+        "{\"1\":4}",
+        sval_json::stream_to_string(UnlabeledEnum::<i32, bool>::Tagged(4)).unwrap()
+    );
+    assert_eq!(
+        "{\"3\":{}}",
+        sval_json::stream_to_string(UnlabeledEnum::<i32, bool>::EmptyMapStruct(EmptyMap {}))
+            .unwrap()
+    );
+    assert_eq!(
+        "{\"5\":[]}",
+        sval_json::stream_to_string(UnlabeledEnum::<i32, bool>::EmptySeq(&[])).unwrap()
+    );
+    assert_eq!(
+        "{\"2\":{\"field_0\":1,\"field_1\":true}}",
+        sval_json::stream_to_string(UnlabeledEnum::<i32, bool>::MapStruct {
+            field_0: 1,
+            field_1: true
+        })
+        .unwrap()
+    );
+    assert_eq!(
+        "{\"4\":[1,true]}",
+        sval_json::stream_to_string(UnlabeledEnum::<i32, bool>::SeqStruct(1, true)).unwrap()
+    );
+    assert_eq!(
+        "{\"6\":{\"2\":{\"field_0\":1,\"field_1\":true}}}",
+        sval_json::stream_to_string(UnlabeledEnum::<i32, bool>::Nested(Box::new(
+            UnlabeledEnum::<i32, bool>::MapStruct {
+                field_0: 1,
+                field_1: true
+            }
+        )))
+        .unwrap()
+    );
+}
+
+#[test]
+fn stream_unlabeled_unindexed_enum() {
+    assert_eq!(
+        "null",
+        sval_json::stream_to_string(UnlabeledUnindexedEnum::<i32, bool>::Constant).unwrap()
+    );
+    assert_eq!(
+        "4",
+        sval_json::stream_to_string(UnlabeledUnindexedEnum::<i32, bool>::Tagged(4)).unwrap()
+    );
+    assert_eq!(
+        "{}",
+        sval_json::stream_to_string(UnlabeledUnindexedEnum::<i32, bool>::EmptyMapStruct(
+            EmptyMap {}
+        ))
+        .unwrap()
+    );
+    assert_eq!(
+        "[]",
+        sval_json::stream_to_string(UnlabeledUnindexedEnum::<i32, bool>::EmptySeq(&[])).unwrap()
+    );
+    assert_eq!(
+        "{\"field_0\":1,\"field_1\":true}",
+        sval_json::stream_to_string(UnlabeledUnindexedEnum::<i32, bool>::MapStruct {
+            field_0: 1,
+            field_1: true
+        })
+        .unwrap()
+    );
+    assert_eq!(
+        "[1,true]",
+        sval_json::stream_to_string(UnlabeledUnindexedEnum::<i32, bool>::SeqStruct(1, true))
+            .unwrap()
+    );
+    assert_eq!(
+        "{\"field_0\":1,\"field_1\":true}",
+        sval_json::stream_to_string(UnlabeledUnindexedEnum::<i32, bool>::Nested(Box::new(
+            UnlabeledUnindexedEnum::<i32, bool>::MapStruct {
+                field_0: 1,
+                field_1: true
+            }
+        )))
         .unwrap()
     );
 }
@@ -334,56 +447,6 @@ fn stream_empty_enum() {
 }
 
 #[test]
-fn stream_unlabeled_tag() {
-    struct Tag;
-
-    impl sval::Value for Tag {
-        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
-            &'sval self,
-            stream: &mut S,
-        ) -> sval::Result {
-            stream.tag(None, None, Some(&sval::Index::new(1)))
-        }
-    }
-
-    assert_eq!("1", sval_json::stream_to_string(Tag).unwrap());
-}
-
-#[test]
-fn stream_unlabeled_tag_variant() {
-    struct Enum;
-
-    impl sval::Value for Enum {
-        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
-            &'sval self,
-            stream: &mut S,
-        ) -> sval::Result {
-            stream.enum_begin(None, Some(&sval::Label::new("Enum")), None)?;
-            stream.tag(None, None, Some(&sval::Index::new(1)))?;
-            stream.enum_end(None, Some(&sval::Label::new("Enum")), None)
-        }
-    }
-
-    assert_eq!("1", sval_json::stream_to_string(Enum).unwrap());
-}
-
-#[test]
-fn stream_unlabeled_unindexed_tag() {
-    struct Tag;
-
-    impl sval::Value for Tag {
-        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
-            &'sval self,
-            stream: &mut S,
-        ) -> sval::Result {
-            stream.tag(None, None, None)
-        }
-    }
-
-    assert_eq!("null", sval_json::stream_to_string(Tag).unwrap());
-}
-
-#[test]
 fn stream_unlabeled_empty_enum() {
     struct Enum;
 
@@ -415,6 +478,89 @@ fn stream_unlabeled_unindexed_empty_enum() {
     }
 
     assert_eq!("null", sval_json::stream_to_string(Enum).unwrap());
+}
+
+#[test]
+fn stream_empty_tagged() {
+    struct Tagged;
+
+    impl sval::Value for Tagged {
+        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
+            &'sval self,
+            stream: &mut S,
+        ) -> sval::Result {
+            stream.tagged_begin(None, Some(&sval::Label::new("Tagged")), None)?;
+            stream.tagged_end(None, Some(&sval::Label::new("Tagged")), None)
+        }
+    }
+
+    assert_eq!("\"Tagged\"", sval_json::stream_to_string(Tagged).unwrap());
+}
+
+#[test]
+fn stream_unlabeled_empty_tagged() {
+    struct Tagged;
+
+    impl sval::Value for Tagged {
+        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
+            &'sval self,
+            stream: &mut S,
+        ) -> sval::Result {
+            stream.tagged_begin(None, None, Some(&sval::Index::new(1)))?;
+            stream.tagged_end(None, None, Some(&sval::Index::new(1)))
+        }
+    }
+
+    assert_eq!("1", sval_json::stream_to_string(Tagged).unwrap());
+}
+
+#[test]
+fn stream_unlabeled_unindexed_empty_tagged() {
+    struct Tagged;
+
+    impl sval::Value for Tagged {
+        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
+            &'sval self,
+            stream: &mut S,
+        ) -> sval::Result {
+            stream.tagged_begin(None, None, None)?;
+            stream.tagged_end(None, None, None)
+        }
+    }
+
+    assert_eq!("null", sval_json::stream_to_string(Tagged).unwrap());
+}
+
+#[test]
+fn stream_unlabeled_tag() {
+    struct Tag;
+
+    impl sval::Value for Tag {
+        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
+            &'sval self,
+            stream: &mut S,
+        ) -> sval::Result {
+            stream.tag(None, None, Some(&sval::Index::new(1)))
+        }
+    }
+
+    assert_eq!("1", sval_json::stream_to_string(Tag).unwrap());
+}
+
+#[test]
+fn stream_unlabeled_unindexed_tag() {
+    struct Tag;
+
+    impl sval::Value for Tag {
+        fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
+            &'sval self,
+            stream: &mut S,
+        ) -> sval::Result {
+            stream.tag(None, None, None)
+        }
+    }
+
+    assert_eq!("null", sval_json::stream_to_string(Tag).unwrap());
 }
 
 #[test]

--- a/nested/src/error.rs
+++ b/nested/src/error.rs
@@ -22,7 +22,7 @@ enum ErrorKind {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            ErrorKind::Buffer(_) => {
+            ErrorKind::Buffer(ref _e) => {
                 write!(f, "failed to buffer a value")
             }
             ErrorKind::InvalidValue { reason } => {

--- a/nested/src/lib.rs
+++ b/nested/src/lib.rs
@@ -31,10 +31,7 @@ use self::flat::FlatStream;
 /**
 Stream a value through a stream.
 */
-pub fn stream<'sval, S: Stream<'sval>>(
-    stream: S,
-    value: impl ValueRef<'sval>,
-) -> Result<S::Ok> {
+pub fn stream<'sval, S: Stream<'sval>>(stream: S, value: impl ValueRef<'sval>) -> Result<S::Ok> {
     stream.value(value)
 }
 
@@ -1085,7 +1082,10 @@ pub mod default_stream {
         }
 
         impl<'a> sval::Value for Tag<'a> {
-            fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+            fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
+                &'sval self,
+                stream: &mut S,
+            ) -> sval::Result {
                 self.stream_ref(stream)
             }
         }
@@ -1111,7 +1111,15 @@ pub mod default_stream {
             }
         }
 
-        stream.tagged(tag.clone(), label.clone(), index, Tag { tag: tag.as_ref(), label: label.as_ref() })
+        stream.tagged(
+            tag.clone(),
+            label.clone(),
+            index,
+            Tag {
+                tag: tag.as_ref(),
+                label: label.as_ref(),
+            },
+        )
     }
 
     /**
@@ -1412,12 +1420,14 @@ mod tests {
         }
 
         assert_eq!(
-            Value::Tag(Tag::new(
-                Some(sval::tags::RUST_OPTION_NONE),
-                Some(sval::Label::new("None")),
-                Some(sval::Index::new(0))
-            )
-            .unwrap()),
+            Value::Tag(
+                Tag::new(
+                    Some(sval::tags::RUST_OPTION_NONE),
+                    Some(sval::Label::new("None")),
+                    Some(sval::Index::new(0))
+                )
+                .unwrap()
+            ),
             ToValue::default().value_ref(&None::<Inner>).unwrap()
         );
 
@@ -1430,22 +1440,16 @@ mod tests {
                 )
                 .unwrap(),
                 value: Box::new(Value::Record(Record {
-                    tag: Tag::new(
-                        None,
-                        Some(sval::Label::new("Inner")),
-                        None,
-                    )
-                    .unwrap(),
+                    tag: Tag::new(None, Some(sval::Label::new("Inner")), None,).unwrap(),
                     entries: vec![
                         (sval::Label::new("a"), Value::I64(42)),
                         (sval::Label::new("b"), Value::Bool(true)),
                     ]
                 }))
             }),
-            ToValue::default().value_ref(&Some(Inner {
-                a: 42,
-                b: true,
-            })).unwrap()
+            ToValue::default()
+                .value_ref(&Some(Inner { a: 42, b: true }))
+                .unwrap()
         );
     }
 

--- a/serde/src/to_serialize.rs
+++ b/serde/src/to_serialize.rs
@@ -681,11 +681,3 @@ impl<'sval, S: serde::ser::SerializeTupleVariant> StreamTuple<'sval>
         }
     }
 }
-
-struct Bytes<'sval>(&'sval [u8]);
-
-impl<'sval> serde::Serialize for Bytes<'sval> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self.0)
-    }
-}

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{std::convert::TryInto, Index, Label, Result, Stream, Tag};
+use crate::{Index, Label, Result, Stream, Tag};
 
 /**
 A producer of structured data.


### PR DESCRIPTION
This PR cleans up some new dead code lints and attempts to fall back to streaming a tag as its index if it has one but is missing a label.