### PR TITLE
Use uncooked ident as the label

### DIFF
--- a/buffer/src/error.rs
+++ b/buffer/src/error.rs
@@ -69,11 +69,11 @@ impl Error {
         `sval_serde`, then you can enable their `alloc` or `std` features instead.
         */
 
-        #[cfg(all(debug_assertions, not(no_debug_assertions), not(test)))]
+        #[cfg(all(debug_assertions, not(feature = "no_debug_assertions"), not(test)))]
         {
-            panic!("attempt to allocate for {} would fail; add the `alloc` feature of `sval_buffer` or the depdendent `sval_*` library to support allocation. This call will error instead of panicking in release builds. Add the `no_debug_assertions` feature of `sval_buffer` if this error is expected.", method);
+            panic!("attempt to allocate for {} would fail; add the `alloc` feature of `sval_buffer` or the depdendent `sval_*` library to support allocation. This call will error instead of panicking in release builds. Add the `feature = no_debug_assertions` feature of `sval_buffer` if this error is expected.", method);
         }
-        #[cfg(not(all(debug_assertions, not(no_debug_assertions), not(test))))]
+        #[cfg(not(all(debug_assertions, not(feature = "no_debug_assertions"), not(test))))]
         {
             Error(ErrorKind::NoAlloc { method })
         }

--- a/derive/test/lib.rs
+++ b/derive/test/lib.rs
@@ -27,6 +27,26 @@ mod derive_struct {
     }
 
     #[test]
+    fn uncooked() {
+        #[derive(Value)]
+        struct RecordTuple {
+            r#type: i32,
+        }
+
+        assert_tokens(&RecordTuple { r#type: 42 }, {
+            use sval_test::Token::*;
+
+            &[
+                RecordTupleBegin(None, Some(sval::Label::new("RecordTuple")), None, Some(1)),
+                RecordTupleValueBegin(None, sval::Label::new("type"), sval::Index::new(0)),
+                I32(42),
+                RecordTupleValueEnd(None, sval::Label::new("type"), sval::Index::new(0)),
+                RecordTupleEnd(None, Some(sval::Label::new("RecordTuple")), None),
+            ]
+        })
+    }
+
+    #[test]
     fn generic() {
         #[derive(Value)]
         struct RecordTuple<S> {
@@ -608,6 +628,19 @@ mod derive_unit_struct {
             &[Tag(None, Some(sval::Label::new("Tag")), None)]
         })
     }
+
+    #[test]
+    #[allow(non_camel_case_types)]
+    fn uncooked() {
+        #[derive(Value)]
+        struct r#type;
+
+        assert_tokens(&r#type, {
+            use sval_test::Token::*;
+
+            &[Tag(None, Some(sval::Label::new("type")), None)]
+        })
+    }
 }
 
 mod derive_enum {
@@ -701,6 +734,29 @@ mod derive_enum {
                     None,
                     Some(sval::Label::new("Tuple")),
                     Some(sval::Index::new(3)),
+                ),
+                EnumEnd(None, Some(sval::Label::new("Enum")), None),
+            ]
+        });
+    }
+
+    #[test]
+    #[allow(non_camel_case_types)]
+    fn uncooked() {
+        #[derive(Value)]
+        enum Enum {
+            r#type,
+        }
+
+        assert_tokens(&Enum::r#type, {
+            use sval_test::Token::*;
+
+            &[
+                EnumBegin(None, Some(sval::Label::new("Enum")), None),
+                Tag(
+                    None,
+                    Some(sval::Label::new("type")),
+                    Some(sval::Index::new(0)),
                 ),
                 EnumEnd(None, Some(sval::Label::new("Enum")), None),
             ]

--- a/derive_macros/src/label.rs
+++ b/derive_macros/src/label.rs
@@ -1,4 +1,4 @@
-use syn::Ident;
+use syn::{ext::IdentExt, Ident};
 
 #[derive(Debug, Clone)]
 pub(crate) enum LabelValue {
@@ -22,7 +22,7 @@ fn explicit_label(explicit: LabelValue) -> Label {
 
 fn ident_label(ident: &Ident) -> Label {
     Label::Implicit({
-        let ident = ident.to_string();
+        let ident = ident.unraw().to_string();
         quote!(#ident)
     })
 }


### PR DESCRIPTION
Raw identifiers aren't very common, but when they appear we should use the "raw" version of them as the label instead of the prefixed one.