### PR TITLE
Fix support for 128bit numbers streamed via serde

### DIFF
--- a/nested/Cargo.toml
+++ b/nested/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["encoding", "no-std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(no_debug_assertions)'] }
+
 [features]
 default = ["alloc"]
 std = ["alloc", "sval/std", "sval_buffer/std"]

--- a/serde/src/to_value.rs
+++ b/serde/src/to_value.rs
@@ -147,6 +147,10 @@ impl<'sval, S: sval::Stream<'sval>> serde::Serializer for Stream<S> {
         self.stream_value(v)
     }
 
+    fn serialize_i128(mut self, v: i128) -> Result<Self::Ok, Self::Error> {
+        self.stream_value(v)
+    }
+
     fn serialize_u8(mut self, v: u8) -> Result<Self::Ok, Self::Error> {
         self.stream_value(v)
     }
@@ -160,6 +164,10 @@ impl<'sval, S: sval::Stream<'sval>> serde::Serializer for Stream<S> {
     }
 
     fn serialize_u64(mut self, v: u64) -> Result<Self::Ok, Self::Error> {
+        self.stream_value(v)
+    }
+
+    fn serialize_u128(mut self, v: u128) -> Result<Self::Ok, Self::Error> {
         self.stream_value(v)
     }
 

--- a/serde/test/lib.rs
+++ b/serde/test/lib.rs
@@ -142,6 +142,26 @@ fn option_none_to_serialize() {
 }
 
 #[test]
+fn u128_to_serialize() {
+    // NOTE: Can't check the `serde` end of this because `serde_test`
+    // lacks 128bit number support
+    let v = 42u128;
+
+    let sval = &{
+        use sval_test::Token::*;
+
+        [U128(42)]
+    };
+
+    assert_tokens(&sval_serde::ToValue::new(&v), sval);
+
+    assert_tokens(
+        &sval_serde::ToValue::new(sval_serde::ToSerialize::new(&v)),
+        sval,
+    );
+}
+
+#[test]
 fn map_to_serialize() {
     test_case(
         {


### PR DESCRIPTION
`serde` defaults to failing when encountering 128bit numbers. A few of these were missed when converting a `Serialize` into a `Value`, breaking serialization.