### PR TITLE
Add miri to CI and rework Label internals

### DIFF
--- a/.github/workflows/sval.yml
+++ b/.github/workflows/sval.yml
@@ -52,3 +52,24 @@ jobs:
 
       - name: Powerset
         run: cargo hack check --each-feature --exclude-features std,alloc -Z avoid-dev-deps --target thumbv6m-none-eabi
+
+  miri:
+    name: Test (Miri)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          cargo +nightly miri setup
+
+      - name: Default features
+        run: cargo +nightly miri test --lib
+
+      - name: No features
+        run: cargo +nightly miri test --lib --no-default-features
+
+      - name: All features
+        run: cargo +nightly miri test --all-features --lib

--- a/flatten/src/label.rs
+++ b/flatten/src/label.rs
@@ -114,15 +114,18 @@ impl<'sval> LabelBuf<'sval> {
             LabelBuf::Text(text) => f(&Label::new_computed(text.as_str())),
             LabelBuf::I128(v) => {
                 let mut buf = itoa::Buffer::new();
-                f(&Label::new_computed(buf.format(*v)))
+                let r= f(&Label::new_computed(buf.format(*v)));
+                r
             }
             LabelBuf::U128(v) => {
                 let mut buf = itoa::Buffer::new();
-                f(&Label::new_computed(buf.format(*v)))
+                let r = f(&Label::new_computed(buf.format(*v)));
+                r
             }
             LabelBuf::F64(v) => {
                 let mut buf = ryu::Buffer::new();
-                f(&Label::new_computed(buf.format(*v)))
+                let r =f(&Label::new_computed(buf.format(*v)));
+                r
             }
         }
     }


### PR DESCRIPTION
Miri doesn't like having a `Box` that we store by-value along with a pointer into its data. This PR slightly reworks the internals of `Label` to better appease its rules.