### PR TITLE
Add support for tag hints

### DIFF
--- a/buffer/src/value.rs
+++ b/buffer/src/value.rs
@@ -2244,7 +2244,62 @@ mod alloc_tests {
 
     #[test]
     fn buffer_tag_hints() {
-        todo!()
+        let mut value = ValueBuf::new();
+
+        value.tag_hint(&sval::Tag::new("test")).unwrap();
+
+        value.seq_begin(Some(2)).unwrap();
+
+        value.seq_value_begin().unwrap();
+        value.tag_hint(&sval::Tag::new("test")).unwrap();
+        value.bool(false).unwrap();
+        value.seq_value_end().unwrap();
+
+        value.seq_value_begin().unwrap();
+        value.bool(true).unwrap();
+        value.seq_value_end().unwrap();
+
+        value.seq_end().unwrap();
+
+        value.tag_hint(&sval::Tag::new("test")).unwrap();
+
+        let expected = vec![
+            ValuePart {
+                kind: ValueKind::TagHint {
+                    tag: sval::Tag::new("test"),
+                },
+            },
+            ValuePart {
+                kind: ValueKind::Seq {
+                    len: 5,
+                    num_entries_hint: Some(2),
+                },
+            },
+            ValuePart {
+                kind: ValueKind::SeqValue { len: 2 },
+            },
+            ValuePart {
+                kind: ValueKind::TagHint {
+                    tag: sval::Tag::new("test"),
+                },
+            },
+            ValuePart {
+                kind: ValueKind::Bool(false),
+            },
+            ValuePart {
+                kind: ValueKind::SeqValue { len: 1 },
+            },
+            ValuePart {
+                kind: ValueKind::Bool(true),
+            },
+            ValuePart {
+                kind: ValueKind::TagHint {
+                    tag: sval::Tag::new("test"),
+                },
+            },
+        ];
+
+        assert_eq!(expected, &*value.parts);
     }
 
     #[test]

--- a/dynamic/src/stream.rs
+++ b/dynamic/src/stream.rs
@@ -87,6 +87,8 @@ mod private {
             index: Option<&sval::Index>,
         ) -> sval::Result;
 
+        fn dispatch_tag_hint(&mut self, tag: &sval::Tag) -> sval::Result;
+
         fn dispatch_record_begin(
             &mut self,
             tag: Option<&sval::Tag>,
@@ -368,6 +370,10 @@ impl<'sval, R: sval::Stream<'sval>> private::DispatchStream<'sval> for R {
         self.tag(tag, label, index)
     }
 
+    fn dispatch_tag_hint(&mut self, tag: &sval::Tag) -> sval::Result {
+        self.tag_hint(tag)
+    }
+
     fn dispatch_record_begin(
         &mut self,
         tag: Option<&sval::Tag>,
@@ -644,6 +650,10 @@ macro_rules! impl_stream {
                 index: Option<&sval::Index>,
             ) -> sval::Result {
                 self.erase_stream().0.dispatch_tag(tag, label, index)
+            }
+
+            fn tag_hint(&mut self, tag: &sval::Tag) -> sval::Result {
+                self.erase_stream().0.dispatch_tag_hint(tag)
             }
 
             fn record_begin(&mut self, tag: Option<&sval::Tag>, label: Option<&sval::Label>, index: Option<&sval::Index>, num_entries_hint: Option<usize>) -> sval::Result {

--- a/flatten/src/flattener.rs
+++ b/flatten/src/flattener.rs
@@ -499,6 +499,17 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
     }
 
     #[inline]
+    fn tag_hint(
+        &mut self,
+        tag: &Tag,
+    ) -> sval::Result {
+        self.value(
+            |buf| buf.tag_hint(tag),
+            |stream| stream.tag_hint(tag),
+        )
+    }
+
+    #[inline]
     fn record_begin(
         &mut self,
         tag: Option<&Tag>,

--- a/flatten/src/map.rs
+++ b/flatten/src/map.rs
@@ -262,6 +262,10 @@ impl<'sval, S: Stream<'sval>> Stream<'sval> for PassThru<S> {
         self.stream.tag(tag, label, index)
     }
 
+    fn tag_hint(&mut self, tag: &Tag) -> sval::Result {
+        self.stream.tag_hint(tag)
+    }
+
     fn record_begin(
         &mut self,
         tag: Option<&Tag>,

--- a/nested/src/lib.rs
+++ b/nested/src/lib.rs
@@ -1,5 +1,10 @@
 /*!
 A variant of [`sval::Stream`] for cases where a recursive API is needed.
+
+# Limitations
+
+Streaming via `sval_nested` will discard any [`sval::Stream::tag_hint`]s. `sval` allows tag hints to
+appear anywhere in a stream, but this library enforces a stricter lifecycle, making those hints unreliable.
 */
 
 #![cfg_attr(not(test), no_std)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -301,6 +301,15 @@ pub trait Stream<'sval> {
     }
 
     /**
+    Use a tag as a hint without streaming it as a value.
+
+    Hints may be given at any point in a stream and may be interpreted by a stream in any way, but can't be required for a correct result.
+    */
+    fn tag_hint(&mut self, tag: &Tag) -> Result {
+        default_stream::tag_hint(self, tag)
+    }
+
+    /**
     Start a record type.
 
     Records may be used as enum variants.
@@ -668,6 +677,12 @@ macro_rules! impl_stream_forward {
             }
 
             #[inline]
+            fn tag_hint(&mut self, tag: &Tag) -> Result {
+                let $bind = self;
+                ($($forward)*).tag_hint(tag)
+            }
+
+            #[inline]
             fn record_begin(&mut self, tag: Option<&Tag>, label: Option<&Label>, index: Option<&Index>, num_entries: Option<usize>) -> Result {
                 let $bind = self;
                 ($($forward)*).record_begin(tag, label, index, num_entries)
@@ -973,6 +988,11 @@ impl<'a, 'b, S: Stream<'a> + ?Sized> Stream<'b> for Computed<S> {
     #[inline]
     fn tag(&mut self, tag: Option<&Tag>, label: Option<&Label>, index: Option<&Index>) -> Result {
         self.0.tag(tag, label, index)
+    }
+
+    #[inline]
+    fn tag_hint(&mut self, tag: &Tag) -> Result {
+        self.0.tag_hint(tag)
     }
 
     #[inline]
@@ -1397,6 +1417,18 @@ pub mod default_stream {
         }
 
         stream.tagged_end(tag, label, index)
+    }
+
+    /**
+    Use a tag as a hint without streaming it as a value.
+
+    Hints may be given at any point in a stream and may be interpreted by a stream in any way, but can't be required for a correct result.
+    */
+    pub fn tag_hint<'sval>(stream: &mut (impl Stream<'sval> + ?Sized), tag: &Tag) -> Result {
+        let _ = stream;
+        let _ = tag;
+
+        Ok(())
     }
 
     /**

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -122,6 +122,10 @@ pub enum Token<'a> {
         Option<sval::Index>,
     ),
     /**
+    [`sval::Stream::tag_hint`]
+    */
+    TagHint(sval::Tag),
+    /**
     [`sval::Stream::text_begin`].
     */
     TextBegin(Option<usize>),
@@ -326,6 +330,9 @@ impl<'a, 'b> sval::Value for AsValue<'a, 'b> {
                 Token::Null => stream.null()?,
                 Token::Tag(tag, label, index) => {
                     stream.tag(tag.as_ref(), label.as_ref(), index.as_ref())?
+                }
+                Token::TagHint(tag) => {
+                    stream.tag_hint(tag)?;
                 }
                 Token::TextBegin(num_bytes) => stream.text_begin(*num_bytes)?,
                 Token::TextFragment(v) => stream.text_fragment(*v)?,
@@ -677,6 +684,12 @@ impl<'sval> sval::Stream<'sval> for TokenBuf<'sval> {
             label.map(|label| label.to_owned()),
             index.cloned(),
         ));
+        Ok(())
+    }
+
+    fn tag_hint(&mut self, tag: &sval::Tag) -> sval::Result {
+        self.push(Token::TagHint(tag.clone()));
+
         Ok(())
     }
 
@@ -1084,6 +1097,11 @@ mod tests {
                 Token::TaggedEnd(Some(sval::tags::NUMBER), None, None),
             ],
         );
+    }
+
+    #[test]
+    fn stream_tag_hints() {
+        todo!()
     }
 
     #[test]


### PR DESCRIPTION
Closes #203

This PR adds the following method to `Stream`:

```rust
trait Stream<'sval> {
    fn tag_hint(&mut self, tag: &Tag) -> Result { }
}
```

Tag hints can be given at any point while streaming and are stream-specific, but can't be relied upon to produce a correct result.