### PR TITLE
Check some core crates against 1.61.0

### DIFF
--- a/.github/workflows/buffer.yml
+++ b/.github/workflows/buffer.yml
@@ -44,6 +44,22 @@ jobs:
         working-directory: ./buffer
         run: cargo hack bench --feature-powerset --no-run
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        working-directory: ./buffer
+        run: cargo check --all-features
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -27,6 +27,22 @@ jobs:
         working-directory: ./dynamic
         run: cargo hack test --feature-powerset -Z minimal-versions
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        working-directory: ./dynamic
+        run: cargo check --all-features
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/.github/workflows/flatten.yml
+++ b/.github/workflows/flatten.yml
@@ -31,6 +31,22 @@ jobs:
         working-directory: ./flatten
         run: cargo hack test --feature-powerset -Z minimal-versions
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        working-directory: ./flatten
+        run: cargo check --all-features
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/.github/workflows/nested.yml
+++ b/.github/workflows/nested.yml
@@ -44,6 +44,22 @@ jobs:
         working-directory: ./nested
         run: cargo hack bench --feature-powerset --no-run
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        working-directory: ./nested
+        run: cargo check --all-features
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/.github/workflows/ref.yml
+++ b/.github/workflows/ref.yml
@@ -27,6 +27,22 @@ jobs:
         working-directory: ./ref
         run: cargo hack test --feature-powerset -Z minimal-versions
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        working-directory: ./ref
+        run: cargo check --all-features
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/.github/workflows/serde.yml
+++ b/.github/workflows/serde.yml
@@ -31,6 +31,22 @@ jobs:
         working-directory: ./serde/test
         run: cargo hack test --feature-powerset
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        working-directory: ./serde
+        run: cargo check --all-features
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/.github/workflows/sval.yml
+++ b/.github/workflows/sval.yml
@@ -53,6 +53,21 @@ jobs:
       - name: Powerset
         run: cargo hack check --each-feature --exclude-features std,alloc -Z avoid-dev-deps --target thumbv6m-none-eabi
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        run: cargo check --all-features
+
   miri:
     name: Test (Miri)
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,19 @@ jobs:
       - name: Minimal Versions
         working-directory: ./test
         run: cargo hack test --feature-powerset -Z minimal-versions
+
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain add 1.61.0 --profile minimal
+          rustup default 1.61.0
+
+      - name: Check
+        working-directory: ./test
+        run: cargo check --all-features


### PR DESCRIPTION
We're not hard-committing to an MSRV here, but we want to tell if we bump it accidentally so we can either avoid it or propagate the change in `log`.