### PR TITLE
Fill in more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,132 @@ Implementations of [`Value`]() should provide a [`Stream`]() with borrowed data 
 
 `sval`'s [`Error`]() type doesn't carry any state of its own. It only signals early termination of the [`Stream`]() which may be because its job is done, or because it failed. It's up to the [`Stream`]() to carry whatever state it needs to provide meaningful errors.
 
+## Data model
+
+This section descibes `sval`'s data model in detail using examples in Rust syntax. Some types in `sval`'s model aren't representable in Rust yet, so they use pseudo syntax.
+
+### Base model
+
+#### Nulls
+
+```rust
+null
+```
+
+```rust
+stream.null()?;
+```
+
+#### Booleans
+
+```rust
+bool
+```
+
+```rust
+stream.bool(true)?;
+```
+
+#### Integers
+
+```rust
+i64
+```
+
+```rust
+stream.i64(-1)?;
+```
+
+#### Binary floating point numbers
+
+```rust
+f64
+```
+
+```rust
+stream.f64(3.14)?;
+```
+
+#### Text
+
+```rust
+[str]
+```
+
+```rust
+stream.text_begin(None)?;
+
+stream.text_fragment("Hello, ")?;
+stream.text_fragment("World")?;
+
+stream.text_end()?;
+```
+
+Note that `sval` text is an array of strings.
+
+#### Sequences
+
+```rust
+[dyn T]
+```
+
+```rust
+stream.seq_begin(None)?;
+
+stream.seq_value_begin()?;
+stream.i64(-1)?;
+stream.seq_value_end()?;
+
+stream.seq_value_begin()?;
+stream.bool(true)?;
+stream.seq_value_end()?;
+
+stream.seq_end()?;
+```
+
+Note that Rust arrays are homogeneous, but `sval` sequences are heterogeneous.
+
+### Extended model
+
+#### Maps
+
+```rust
+[(dyn K, dyn V)]
+```
+
+```rust
+stream.map_begin(None)?;
+
+stream.map_key_begin()?;
+stream.i64(0)?;
+stream.map_key_end()?;
+
+stream.map_value_begin()?;
+stream.bool(false)?;
+stream.map_value_end()?;
+
+stream.map_key_begin()?;
+stream.i64(1)?;
+stream.map_key_end()?;
+
+stream.map_value_begin()?;
+stream.bool(true)?;
+stream.map_value_end()?;
+
+stream.map_end()?;
+```
+
+Note that most Rust maps are homogeneous, but `sval` maps are heterogeneous.
+
+Maps reduce to a sequence of 2D sequences in the base data model.
+
+### Type system
+
+`sval` has an implicit structural type system based on the sequence of calls a [`Stream`]() receives, and any [`Label`](), [`Index`](), or [`Tag`]() on them, with the following exceptions:
+
+1. Maps and sequences are untyped. Their type doesn't depend on the types of their elements, or on their length.
+2. Enums holding differently typed variants have the same type.
+
 ## Ecosystem
 
 `sval` is a general framework with specific serialization formats and utilities provided as external libraries:

--- a/README.md
+++ b/README.md
@@ -6,36 +6,24 @@
 
 ## What is it?
 
-`sval` is a serialization-only framework for Rust. It has a simple, but expressive design that can express any Rust data
-structure, plus some it can't yet. It was originally designed as a niche framework for structured logging, targeting
-serialization to [JSON](), [protobuf](), and Rust's [Debug-style formatting](). The project has evolved beyond this point into a fully general
-and capable framework for introspecting runtime data.
+`sval` is a serialization-only framework for Rust. It has a simple, but expressive design that can express any Rust data structure, plus some it can't yet. It was originally designed as a niche framework for structured logging, targeting serialization to [JSON](), [protobuf](), and Rust's [Debug-style formatting](). The project has evolved beyond this point into a fully general and capable framework for introspecting runtime data.
 
-The core of `sval` is the [`Stream`]() trait. It defines the data model and features of the framework. `sval` makes
-a few different API design decisions compared to [`serde`](), the de-facto choice, to better accommodate the needs of Rust diagnostic frameworks:
+The core of `sval` is the [`Stream`]() trait. It defines the data model and features of the framework. `sval` makes a few different API design decisions compared to [`serde`](), the de-facto choice, to better accommodate the needs of Rust diagnostic frameworks:
 
-1. **Simple API.** The [`Stream`]() trait has only a few required members that all values are forwarded to.
-   This makes it easy to write bespoke handling for specific data types without needing to implement unrelated methods.
-2. **`dyn`-friendly.** The [`Stream`]() trait is internally mutable, so is trivial to make `dyn`-compatible without intermediate boxing, making
-   it possible to use in no-std environments.
+1. **Simple API.** The [`Stream`]() trait has only a few required members that all values are forwarded to. This makes it easy to write bespoke handling for specific data types without needing to implement unrelated methods.
+2. **`dyn`-friendly.** The [`Stream`]() trait is internally mutable, so is trivial to make `dyn`-compatible without intermediate boxing, making it possible to use in no-std environments.
 3. **Buffer-friendly.** The [`Stream`]() trait is non-recursive, so values can be buffered as a flat stream of tokens and replayed later.
-4. **Borrowing as an optimization.** The [`Stream`]() trait may accept borrowed text or binary fragments for a specific lifetime `'sval`,
-   but is also required to accept temporary ones too. This makes it possible to optimize away allocations where possible, but still force
-   them if it's required.
-5. **Broadly compatible.** `sval` imposes very few constraints of its own, so it can trivially translate implementations of [`serde::Serialize`]()
-   into implementations of [`sval::Value`]().
+4. **Borrowing as an optimization.** The [`Stream`]() trait may accept borrowed text or binary fragments for a specific lifetime `'sval`, but is also required to accept temporary ones too. This makes it possible to optimize away allocations where possible, but still force them if it's required.
+5. **Broadly compatible.** `sval` imposes very few constraints of its own, so it can trivially translate implementations of [`serde::Serialize`]() into implementations of [`sval::Value`]().
 
 `sval`'s data model takes inspiration from [CBOR](), specifically:
 
-1. **Small core.** The base data model of `sval` is small. The required members of the [`Stream`]() trait only includes nulls, booleans,
-   text, 64-bit signed integers, 64-bit floating point numbers, and sequences. All other types, like arbitrary-precision floating point numbers,
-   records, and tuples, are representable in the base data model.
-2. **Extensible tags.** Users can define _tags_ that extend `sval`'s data model with new semantics. Examples of tags include Rust's `Some` and `None`
-   variants, constant-sized arrays, text that doesn't require JSON escaping, and anything else you might need.
+1. **Small core.** The base data model of `sval` is small. The required members of the [`Stream`]() trait only includes nulls, booleans, text, 64-bit signed integers, 64-bit floating point numbers, and sequences. All other types, like arbitrary-precision floating point numbers, records, and tuples, are representable in the base data model.
+2. **Extensible tags.** Users can define _tags_ that extend `sval`'s data model with new semantics. Examples of tags include Rust's `Some` and `None` variants, constant-sized arrays, text that doesn't require JSON escaping, and anything else you might need.
 
 ## Getting started
 
-Add `sval` to your `Cargo.toml`:
+This section is a high-level guided tour of `sval`'s design and API. To get started, add `sval` to your `Cargo.toml`:
 
 ```toml
 [dependencies.sval]
@@ -43,7 +31,19 @@ version = "2.14.1"
 features = ["derive"]
 ```
 
-Derive [`Value`]() on your Rust types, just like you do with `serde`:
+### Serializing a value as JSON
+
+As a quick example, here's how you can use `sval` to serialize a runtime value as JSON.
+
+First, add [`sval_json`]() to your `Cargo.toml`:
+
+```toml
+[dependencies.sval_json]
+version = "2.14.1"
+features = ["std"]
+```
+
+Next, derive the [`Value`]() trait on the type you want to serialize, including on any other types it uses in its fields:
 
 ```rust
 #[derive(sval::Value)]
@@ -54,14 +54,7 @@ pub struct MyRecord<'a> {
 }
 ```
 
-Types that derive or implement [`Value`]() can be streamed through an isntance of [`Stream`](). [`sval_json`]() is an example of a stream that
-serializes values to JSON:
-
-```toml
-[dependencies.sval_json]
-version = "2.14.1"
-features = ["std"]
-```
+Finally, use [`stream_to_string`]() to serialize an instance of your type as JSON:
 
 ```rust
 let my_record = MyRecord {
@@ -70,15 +63,158 @@ let my_record = MyRecord {
     field_2: "some text",
 };
 
+// Produces:
+//
 // {"field_0":1,"field_1":true,"field_2":"some text"}
-let json = sval_json::stream_to_string(my_record);
+let json: String = sval_json::stream_to_string(my_record)?;
 ```
 
-[`Stream`]()s can do more than just serialize data into an interchange format. [`sval_buffer`]() is a stream that buffers temporary values into owned,
-thread-safe ones. [`sval_flatten`]() is a stream that removes a level of nesting from a field. The [`Value`]() trait's conversion methods,
-like [`Value::to_text`](), are streams that attempt to cast an arbitrary value to a concrete type in `sval`'s data model.
+### The `Value` trait
 
-Here's an example of a stream that attempts to extract a specific field of a value as an `i32`:
+The previous example didn't reveal a lot of detail about how `sval` works, only that there's a [`Value`]() trait involved, and it somehow allows us to convert an instance of the `MyRecord` struct into a JSON object. Using [`cargo expand`](), we can peek behind the covers and see what the `Value` trait does. The previous example expands to something like this:
+
+```rust
+impl<'a> sval::Value for MyRecord<'a> {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        let type_label = Some(&sval::Label::new("MyRecord").with_tag(&sval::tags::VALUE_IDENT));
+        let type_index = None;
+
+        stream.record_tuple_begin(None, type_label, type_index, Some(3))?;
+
+        let mut field_index = 0;
+
+        // field_0
+        {
+            field_index += 1;
+
+            let field_index = &sval::Index::from(field_index - 1).with_tag(&sval::tags::VALUE_OFFSET);
+            let field_label = &sval::Label::new("field_0").with_tag(&sval::tags::VALUE_IDENT);
+
+            stream.record_tuple_value_begin(None, field_label, field_index)?;
+            stream.value(&self.field_0)?;
+            stream.record_tuple_value_end(None, field_label, field_index)?;
+        }
+
+        // field_1
+        {
+            field_index += 1;
+
+            let field_index = &sval::Index::from(field_index - 1).with_tag(&sval::tags::VALUE_OFFSET);
+            let field_label = &sval::Label::new("field_1").with_tag(&sval::tags::VALUE_IDENT);
+
+            stream.record_tuple_value_begin(None, field_label, field_index)?;
+            stream.value(&self.field_1)?;
+            stream.record_tuple_value_end(None, field_label, field_index)?;
+        }
+
+        // field_2
+        {
+            field_index += 1;
+
+            let field_index = &sval::Index::from(field_index - 1).with_tag(&sval::tags::VALUE_OFFSET);
+            let field_label = &sval::Label::new("field_2").with_tag(&sval::tags::VALUE_IDENT);
+            
+            stream.record_tuple_value_begin(None, field_label, field_index)?;
+            stream.value(&self.field_2)?;
+            stream.record_tuple_value_end(None, field_label, field_index)?;
+        }
+
+        stream.record_tuple_end(None, type_label, type_index)
+    }
+}
+```
+
+The [`Value`]() trait has a single required method, `stream`, which is responsible for driving an instance of a [`Stream`]() with its fields. The [`Stream`]() trait defines `sval`'s data model and the mechanics of how data is described in it. In this example, the `MyRecord` struct is represented as a _record tuple_, a type that can be either a _record_ with fields named by a [`Label`](), or a _tuple_ with fields indexed by an [`Index`](). Labels and indexes can be annotated with a [`Tag`]() which add user-defined semantics to them. In this case, the labels carry the [`VALUE_IDENT`]() tag meaning they're valid Rust identifiers, and the indexes carry the [`VALUE_OFFSET`]() tag meanings they're zero-indexed field offsets. The specific type of [`Stream`]() can decide whether to treat the `MyRecord` type as either a record (in the case of JSON) or a tuple (in the case of protobuf), and whether it understands that tags it sees or not.
+
+### The `Stream` trait
+
+Something to notice about the [`Stream`]() API in the expanded `MyRecord` example is that it is _flat_. The call to `record_tuple_begin` doesn't return a new type like `serde`'s `struct_begin` does. The implementor of [`Value`]() is responsible for issuing the correct sequence of [`Stream`]() calls as it works through its structure. The [`Stream`]() can then rely on markers like `record_tuple_value_begin` and `record_tuple_value_end` to know what position within a value it is without needing to track that state itself. The flat API makes dyn-compatibility and buffering simpler, but makes implementing non-trivial streams more difficult, because you can't rely on recursive to manage state.
+
+Recall the way `MyRecord` was converted into JSON earlier:
+
+```rust
+let json: String = sval_json::stream_to_string(my_record)?;
+```
+
+Internally, [`stream_to_string`]() uses an instance of [`Stream`]() that writes JSON tokens for each piece of the value it encounters. For example, `record_tuple_begin` and `record_tuple_end` will emit the corresponding `{` `}` characters for a JSON object.
+
+`sval`'s data model is _layered_. The required methods on [`Stream`]() represent the base data model that more expressive constructs map down to. Here's what a minimal [`Stream`]() that just formats values in `sval`'s base data model looks like:
+
+```rust
+pub struct MyStream;
+
+impl<'sval> sval::Stream<'sval> for MyStream {
+    fn null(&mut self) -> sval::Result {
+        print!("null");
+        Ok(())
+    }
+
+    fn bool(&mut self, v: bool) -> sval::Result {
+        print!("{}", v);
+        Ok(())
+    }
+
+    fn i64(&mut self, v: i64) -> sval::Result {
+        print!("{}", v);
+        Ok(())
+    }
+
+    fn f64(&mut self, v: f64) -> sval::Result {
+        print!("{}", v);
+        Ok(())
+    }
+
+    fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+        print!("\"");
+        Ok(())
+    }
+
+    fn text_fragment_computed(&mut self, fragment: &str) -> sval::Result {
+        print!("{}", fragment.escape_debug());
+
+        Ok(())
+    }
+
+    fn text_end(&mut self) -> sval::Result {
+        print!("\"");
+        Ok(())
+    }
+
+    fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+        print!("[");
+        Ok(())
+    }
+
+    fn seq_value_begin(&mut self) -> sval::Result {
+        Ok(())
+    }
+
+    fn seq_value_end(&mut self) -> sval::Result {
+        print!(",");
+        Ok(())
+    }
+
+    fn seq_end(&mut self) -> sval::Result {
+        print!("]");
+        Ok(())
+    }
+}
+
+let my_record = MyRecord {
+    field_0: 1,
+    field_1: true,
+    field_2: "some text",
+};
+
+// Prints:
+//
+// [["field_0",1,],["field_1",true,],["field_2","some text",],],
+sval::stream(&mut MyStream, my_record);
+```
+
+Recall that the `MyRecord` struct mapped to a `record_tuple` in `sval`'s data model. `record_tuple`s in turn are represented in the base data model as a sequence of 2-dimensional sequences where the first element is the field label and the second is its value.
+
+[`Stream`]()s aren't limited to just serializing data into interchange formats. They can manipulate or interrogate a value any way it likes. Here's an example of a [`Stream`]() that attempts to extract a specific field of a value as an `i32`:
 
 ```rust
 pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
@@ -90,6 +226,8 @@ pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
     }
 
     impl<'a, 'sval> sval::Stream<'sval> for Extract<'a> {
+        // Rust structs that derive `Value`, like `MyRecord` from earlier, are records in `sval`'s data model.
+        // Each field of the record starts with a call to `record_value_begin` with its name.
         fn record_value_begin(&mut self, _: Option<&sval::Tag>, label: &sval::Label) -> sval::Result {
             self.matched_field = label.as_str() == self.field;
             Ok(())
@@ -99,6 +237,9 @@ pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
             Ok(())
         }
 
+        // We're looking for an `i32`, so will attempt to cast an integer we find.
+        // `sval` will forward any convertible integer to `i64` by default.
+        // We could also override the `i32` method here.
         fn i64(&mut self, v: i64) -> sval::Result {
             if self.matched_field {
                 self.extracted = v.try_into().ok();
@@ -107,6 +248,30 @@ pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
             Ok(())
         }
 
+        // `sval` will forward all complex types as sequences by default.
+        // We're only interested in top-level fields of records here, so whenever
+        // we encounter a sequence we increment/decrement our depth to tell how
+        // deeply nested we are.
+        fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+            self.depth += 1;
+            Ok(())
+        }
+    
+        fn seq_value_begin(&mut self) -> sval::Result {
+            Ok(())
+        }
+    
+        fn seq_value_end(&mut self) -> sval::Result {
+            Ok(())
+        }
+    
+        fn seq_end(&mut self) -> sval::Result {
+            self.depth -= 1;
+            Ok(())
+        }
+
+        // These other methods are required members of `Stream`.
+        // We're not interested in them in this example.
         fn null(&mut self) -> sval::Result {
             Ok(())
         }
@@ -130,24 +295,6 @@ pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
         fn f64(&mut self, _: f64) -> sval::Result {
             Ok(())
         }
-    
-        fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
-            self.depth += 1;
-            Ok(())
-        }
-    
-        fn seq_value_begin(&mut self) -> sval::Result {
-            Ok(())
-        }
-    
-        fn seq_value_end(&mut self) -> sval::Result {
-            Ok(())
-        }
-    
-        fn seq_end(&mut self) -> sval::Result {
-            self.depth -= 1;
-            Ok(())
-        }
     }
 
     let mut stream = Extract {
@@ -156,8 +303,30 @@ pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
         matched_field: false,
         extracted: None,
     };
-    
+
     sval::stream(&mut stream, &value).ok()?;
     stream.extracted
 }
+
+let my_record = MyRecord {
+    field_0: 1,
+    field_1: true,
+    field_2: "some text",
+};
+
+assert_eq!(Some(1), get_i32("field_0", &my_record));
 ```
+
+`sval` includes utility [`Stream`]()s for some common use-cases:
+
+- [`sval_buffer`](): Losslessly buffers any [`Value`]() into an owned, thread-safe variant.
+- [`sval_flatten`](): Flatten the fields of a value onto its parent, like `#[serde(flatten)]`.
+- [`sval_nested`](): Buffer `sval`'s flat [`Stream`]() API into a recursive one like `serde`'s. For types that `#[derive(Value)]`, the translation is non-allocating.
+
+### Borrowed data
+
+- `'sval` lifetime and optional borrowing
+
+### Chunking strings
+
+- `text_fragment` for split strings

--- a/README.md
+++ b/README.md
@@ -159,11 +159,6 @@ impl<'sval> sval::Stream<'sval> for MyStream {
         Ok(())
     }
 
-    fn f64(&mut self, v: f64) -> sval::Result {
-        print!("{}", v);
-        Ok(())
-    }
-
     fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
         print!("\"");
         Ok(())
@@ -289,10 +284,6 @@ pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
         }
     
         fn text_end(&mut self) -> sval::Result {
-            Ok(())
-        }
-    
-        fn f64(&mut self, _: f64) -> sval::Result {
             Ok(())
         }
     }
@@ -426,10 +417,6 @@ pub fn to_text(value: &(impl Value + ?Sized)) -> Option<&str> {
             sval::error()
         }
 
-        fn f64(&mut self, _: f64) -> Result {
-            sval::error()
-        }
-
         fn seq_begin(&mut self, _: Option<usize>) -> Result {
             sval::error()
         }
@@ -497,16 +484,6 @@ i64
 
 ```rust
 stream.i64(-1)?;
-```
-
-#### Binary floating point numbers
-
-```rust
-f64
-```
-
-```rust
-stream.f64(3.14)?;
 ```
 
 #### Text

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
 
 ## What is it?
 
-`sval` is a serialization-only framework for Rust. It has a simple, but expressive design that can express any Rust data structure, plus some it can't yet. It was originally designed as a niche framework for structured logging, targeting serialization to [JSON](), [protobuf](), and Rust's [Debug-style formatting](). The project has evolved beyond this point into a fully general and capable framework for introspecting runtime data.
+`sval` is a serialization-only framework for Rust. It has a simple, but expressive design that can express any Rust data structure, plus some it can't yet. It was originally designed as a niche framework for structured logging, targeting serialization to [JSON](https://www.json.org, [protobuf](https://protobuf.dev), and Rust's [Debug-style formatting](https://doc.rust-lang.org/std/fmt/trait.Debug.html). The project has evolved beyond this point into a fully general and capable framework for introspecting runtime data.
 
-The core of `sval` is the [`Stream`]() trait. It defines the data model and features of the framework. `sval` makes a few different API design decisions compared to [`serde`](), the de-facto choice, to better accommodate the needs of Rust diagnostic frameworks:
+The core of `sval` is the [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait. It defines the data model and features of the framework. `sval` makes a few different API design decisions compared to [`serde`](https://serde.rs), the de-facto choice, to better accommodate the needs of Rust diagnostic frameworks:
 
-1. **Simple API.** The [`Stream`]() trait has only a few required members that all values are forwarded to. This makes it easy to write bespoke handling for specific data types without needing to implement unrelated methods.
-2. **`dyn`-friendly.** The [`Stream`]() trait is internally mutable, so is trivial to make `dyn`-compatible without intermediate boxing, making it possible to use in no-std environments.
-3. **Buffer-friendly.** The [`Stream`]() trait is non-recursive, so values can be buffered as a flat stream of tokens and replayed later.
-4. **Borrowing as an optimization.** The [`Stream`]() trait may accept borrowed text or binary fragments for a specific lifetime `'sval`, but is also required to accept temporary ones too. This makes it possible to optimize away allocations where possible, but still force them if it's required.
-5. **Broadly compatible.** `sval` imposes very few constraints of its own, so it can trivially translate implementations of [`serde::Serialize`]() into implementations of [`sval::Value`]().
+1. **Simple API.** The [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait has only a few required members that all values are forwarded to. This makes it easy to write bespoke handling for specific data types without needing to implement unrelated methods.
+2. **`dyn`-friendly.** The [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait is internally mutable, so is trivial to make `dyn`-compatible without intermediate boxing, making it possible to use in no-std environments.
+3. **Buffer-friendly.** The [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait is non-recursive, so values can be buffered as a flat stream of tokens and replayed later.
+4. **Borrowing as an optimization.** The [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait may accept borrowed text or binary fragments for a specific lifetime `'sval`, but is also required to accept temporary ones too. This makes it possible to optimize away allocations where possible, but still force them if it's required.
+5. **Broadly compatible.** `sval` imposes very few constraints of its own, so it can trivially translate implementations of [`serde::Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) into implementations of [`sval::Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html).
 
-`sval`'s data model takes inspiration from [CBOR](), specifically:
+`sval`'s data model takes inspiration from [CBOR](https://cbor.io), specifically:
 
-1. **Small core.** The base data model of `sval` is small. The required members of the [`Stream`]() trait only includes nulls, booleans, text, 64-bit signed integers, 64-bit floating point numbers, and sequences. All other types, like arbitrary-precision floating point numbers, records, and tuples, are representable in the base model.
+1. **Small core.** The base data model of `sval` is small. The required members of the [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait only includes nulls, booleans, text, 64-bit signed integers, 64-bit floating point numbers, and sequences. All other types, like arbitrary-precision floating point numbers, records, and tuples, are representable in the base model.
 2. **Extensible tags.** Users can define _tags_ that extend `sval`'s data model with new semantics. Examples of tags include Rust's `Some` and `None` variants, constant-sized arrays, text that doesn't require JSON escaping, and anything else you might need.
 
 ## Getting started
@@ -35,7 +35,7 @@ features = ["derive"]
 
 As a quick example, here's how you can use `sval` to serialize a runtime value as JSON.
 
-First, add [`sval_json`]() to your `Cargo.toml`:
+First, add [`sval_json`](https://docs.rs/sval_json/2.14.1/sval_json/index.html) to your `Cargo.toml`:
 
 ```toml
 [dependencies.sval_json]
@@ -43,7 +43,7 @@ version = "2.14.1"
 features = ["std"]
 ```
 
-Next, derive the [`Value`]() trait on the type you want to serialize, including on any other types it uses in its fields:
+Next, derive the [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html) trait on the type you want to serialize, including on any other types it uses in its fields:
 
 ```rust
 #[derive(sval::Value)]
@@ -54,7 +54,7 @@ pub struct MyRecord<'a> {
 }
 ```
 
-Finally, use [`stream_to_string`]() to serialize an instance of your type as JSON:
+Finally, use [`stream_to_string`](https://docs.rs/sval_json/2.14.1/sval_json/fn.stream_to_string.html) to serialize an instance of your type as JSON:
 
 ```rust
 let my_record = MyRecord {
@@ -71,7 +71,7 @@ let json: String = sval_json::stream_to_string(my_record)?;
 
 ### The `Value` trait
 
-The previous example didn't reveal a lot of detail about how `sval` works, only that there's a [`Value`]() trait involved, and it somehow allows us to convert an instance of the `MyRecord` struct into a JSON object. Using [`cargo expand`](), we can peek behind the covers and see what the `Value` trait does. The previous example expands to something like this:
+The previous example didn't reveal a lot of detail about how `sval` works, only that there's a [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html) trait involved, and it somehow allows us to convert an instance of the `MyRecord` struct into a JSON object. Using [`cargo expand`](https://github.com/dtolnay/cargo-expand), we can peek behind the covers and see what the `Value` trait does. The previous example expands to something like this:
 
 ```rust
 impl<'a> sval::Value for MyRecord<'a> {
@@ -124,11 +124,11 @@ impl<'a> sval::Value for MyRecord<'a> {
 }
 ```
 
-The [`Value`]() trait has a single required method, `stream`, which is responsible for driving an instance of a [`Stream`]() with its fields. The [`Stream`]() trait defines `sval`'s data model and the mechanics of how data is described in it. In this example, the `MyRecord` struct is represented as a _record tuple_, a type that can be either a _record_ with fields named by a [`Label`](), or a _tuple_ with fields indexed by an [`Index`](). Labels and indexes can be annotated with a [`Tag`]() which add user-defined semantics to them. In this case, the labels carry the [`VALUE_IDENT`]() tag meaning they're valid Rust identifiers, and the indexes carry the [`VALUE_OFFSET`]() tag meanings they're zero-indexed field offsets. The specific type of [`Stream`]() can decide whether to treat the `MyRecord` type as either a record (in the case of JSON) or a tuple (in the case of protobuf), and whether it understands that tags it sees or not.
+The [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html) trait has a single required method, `stream`, which is responsible for driving an instance of a [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) with its fields. The [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait defines `sval`'s data model and the mechanics of how data is described in it. In this example, the `MyRecord` struct is represented as a _record tuple_, a type that can be either a _record_ with fields named by a [`Label`](https://docs.rs/sval/2.14.1/sval/struct.Label.html), or a _tuple_ with fields indexed by an [`Index`](https://docs.rs/sval/2.14.1/sval/struct.Index.html). Labels and indexes can be annotated with a [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html) which add user-defined semantics to them. In this case, the labels carry the [`VALUE_IDENT`](https://docs.rs/sval/2.14.1/sval/tags/constant.VALUE_IDENT.html) tag meaning they're valid Rust identifiers, and the indexes carry the [`VALUE_OFFSET`](https://docs.rs/sval/2.14.1/sval/tags/constant.VALUE_OFFSET.html) tag meanings they're zero-indexed field offsets. The specific type of [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) can decide whether to treat the `MyRecord` type as either a record (in the case of JSON) or a tuple (in the case of protobuf), and whether it understands that tags it sees or not.
 
 ### The `Stream` trait
 
-Something to notice about the [`Stream`]() API in the expanded `MyRecord` example is that it is _flat_. The call to `record_tuple_begin` doesn't return a new type like `serde`'s `struct_begin` does. The implementor of [`Value`]() is responsible for issuing the correct sequence of [`Stream`]() calls as it works through its structure. The [`Stream`]() can then rely on markers like `record_tuple_value_begin` and `record_tuple_value_end` to know what position within a value it is without needing to track that state itself. The flat API makes dyn-compatibility and buffering simpler, but makes implementing non-trivial streams more difficult, because you can't rely on recursive to manage state.
+Something to notice about the [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) API in the expanded `MyRecord` example is that it is _flat_. The call to `record_tuple_begin` doesn't return a new type like `serde`'s `struct_begin` does. The implementor of [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html) is responsible for issuing the correct sequence of [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) calls as it works through its structure. The [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) can then rely on markers like `record_tuple_value_begin` and `record_tuple_value_end` to know what position within a value it is without needing to track that state itself. The flat API makes dyn-compatibility and buffering simpler, but makes implementing non-trivial streams more difficult, because you can't rely on recursive to manage state.
 
 Recall the way `MyRecord` was converted into JSON earlier:
 
@@ -136,9 +136,9 @@ Recall the way `MyRecord` was converted into JSON earlier:
 let json: String = sval_json::stream_to_string(my_record)?;
 ```
 
-Internally, [`stream_to_string`]() uses an instance of [`Stream`]() that writes JSON tokens for each piece of the value it encounters. For example, `record_tuple_begin` and `record_tuple_end` will emit the corresponding `{` `}` characters for a JSON object.
+Internally, [`stream_to_string`](https://docs.rs/sval_json/2.14.1/sval_json/fn.stream_to_string.html) uses an instance of [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) that writes JSON tokens for each piece of the value it encounters. For example, `record_tuple_begin` and `record_tuple_end` will emit the corresponding `{` `}` characters for a JSON object.
 
-`sval`'s data model is _layered_. The required methods on [`Stream`]() represent the base data model that more expressive constructs map down to. Here's what a minimal [`Stream`]() that just formats values in `sval`'s base data model looks like:
+`sval`'s data model is _layered_. The required methods on [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) represent the base data model that more expressive constructs map down to. Here's what a minimal [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) that just formats values in `sval`'s base data model looks like:
 
 ```rust
 pub struct MyStream;
@@ -209,7 +209,7 @@ sval::stream(&mut MyStream, my_record);
 
 Recall that the `MyRecord` struct mapped to a `record_tuple` in `sval`'s data model. `record_tuple`s in turn are represented in the base data model as a sequence of 2-dimensional sequences where the first element is the field label and the second is its value.
 
-[`Stream`]()s aren't limited to just serializing data into interchange formats. They can manipulate or interrogate a value any way it likes. Here's an example of a [`Stream`]() that attempts to extract a specific field of a value as an `i32`:
+[`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html)s aren't limited to just serializing data into interchange formats. They can manipulate or interrogate a value any way it likes. Here's an example of a [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) that attempts to extract a specific field of a value as an `i32`:
 
 ```rust
 pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
@@ -321,7 +321,7 @@ enum Part<'a> {
 pub struct Template<'a>(&'a [Part<'a>]);
 ```
 
-If we wanted to serialize `Template` to a string, we could implement [`Value`](), handling each literal and property as a separate fragment:
+If we wanted to serialize `Template` to a string, we could implement [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html), handling each literal and property as a separate fragment:
 
 ```rust
 impl<'a> sval::Value for Template<'a> {
@@ -361,7 +361,7 @@ let json = sval_json::stream_to_string(template)?;
 
 ### Borrowed data
 
-The [`Stream`]() trait carries a `'sval` lifetime it can use to accept borrowed text and binary values. Borrowing in `sval` is an optimization. Even if a [`Stream`]() uses a concrete `'sval` lifetime, it still needs to handle computed values. Here's an example of a [`Stream`]() that attempts to extract a borrowed string from a value by making use of the `'sval` lifetime:
+The [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) trait carries a `'sval` lifetime it can use to accept borrowed text and binary values. Borrowing in `sval` is an optimization. Even if a [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) uses a concrete `'sval` lifetime, it still needs to handle computed values. Here's an example of a [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) that attempts to extract a borrowed string from a value by making use of the `'sval` lifetime:
 
 ```rust
 pub fn to_text(value: &(impl Value + ?Sized)) -> Option<&str> {
@@ -444,11 +444,11 @@ pub fn to_text(value: &(impl Value + ?Sized)) -> Option<&str> {
 }
 ```
 
-Implementations of [`Value`]() should provide a [`Stream`]() with borrowed data where possible, and only compute it if it needs to.
+Implementations of [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html) should provide a [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) with borrowed data where possible, and only compute it if it needs to.
 
 ### Error handling
 
-`sval`'s [`Error`]() type doesn't carry any state of its own. It only signals early termination of the [`Stream`]() which may be because its job is done, or because it failed. It's up to the [`Stream`]() to carry whatever state it needs to provide meaningful errors.
+`sval`'s [`Error`](https://docs.rs/sval/2.14.1/sval/struct.Error.html) type doesn't carry any state of its own. It only signals early termination of the [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) which may be because its job is done, or because it failed. It's up to the [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) to carry whatever state it needs to provide meaningful errors.
 
 ## Data model
 
@@ -980,9 +980,9 @@ stream.enum_end(None, Some(&sval::Label::new("Enum")), None)?;
 
 #### User-defined tags
 
-`sval` tags, tagged values, records, tuples, enums, and their values can carry a user-defined [`Tag`]() that alters their semantics. A [`Stream`]() may understand a [`Tag`]() and treat its annotated value differently, or it may ignore them. An example of a [`Tag`]() is [`NUMBER`](), which is for text that encodes an arbitrary-precision decimal floating point number with a standardized format. A [`Stream`]() may parse these numbers and encode them differently to regular text.
+`sval` tags, tagged values, records, tuples, enums, and their values can carry a user-defined [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html) that alters their semantics. A [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) may understand a [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html) and treat its annotated value differently, or it may ignore them. An example of a [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html) is [`NUMBER`](https://docs.rs/sval/2.14.1/sval/tags/constant.NUMBER.html), which is for text that encodes an arbitrary-precision decimal floating point number with a standardized format. A [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) may parse these numbers and encode them differently to regular text.
 
-Here's an example of a user-defined [`Tag`]() for treating integers as Unix timestamps, and a [`Stream`]() that understands them:
+Here's an example of a user-defined [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html) for treating integers as Unix timestamps, and a [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) that understands them:
 
 ```rust
 // Define a tag as a constant.
@@ -1089,11 +1089,11 @@ impl<'sval> sval::Stream<'sval> for MyStream {
 }
 ```
 
-The [`Label`]() and [`Index`]() types can also carry a [`Tag`](). An example of a [`Tag`]() you might use on a [`Label`]() is [`VALUE_IDENT`](), for labels that hold a valid Rust identifier.
+The [`Label`](https://docs.rs/sval/2.14.1/sval/struct.Label.html) and [`Index`](https://docs.rs/sval/2.14.1/sval/struct.Index.html) types can also carry a [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html). An example of a [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html) you might use on a [`Label`](https://docs.rs/sval/2.14.1/sval/struct.Label.html) is [`VALUE_IDENT`](https://docs.rs/sval/2.14.1/sval/tags/constant.VALUE_IDENT.html), for labels that hold a valid Rust identifier.
 
 ### Type system
 
-`sval` has an implicit structural type system based on the sequence of calls a [`Stream`]() receives, and the values of any [`Label`](), [`Index`](), or [`Tag`]() on them, with the following exceptions:
+`sval` has an implicit structural type system based on the sequence of calls a [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) receives, and the values of any [`Label`](https://docs.rs/sval/2.14.1/sval/struct.Label.html), [`Index`](https://docs.rs/sval/2.14.1/sval/struct.Index.html), or [`Tag`](https://docs.rs/sval/2.14.1/sval/struct.Tag.html) on them, with the following exceptions:
 
 - Text type does not depend on the composition of fragments, or on their length.
 - Binary type does not depend on the composition of fragments, or on their length.
@@ -1107,11 +1107,11 @@ These rules may be better formalized in the future.
 
 `sval` is a general framework with specific serialization formats and utilities provided as external libraries:
 
-- [`sval_fmt`](): Colorized Rust-style debug formatting.
-- [`sval_json`](): Serialize values as JSON in a `serde`-compatible format.
-- [`sval_protobuf`](): Serialize values as protobuf messages.
-- [`sval_serde`](): Convert between `serde` and `sval`.
-- [`sval_buffer`](): Losslessly buffers any [`Value`]() into an owned, thread-safe variant.
-- [`sval_flatten`](): Flatten the fields of a value onto its parent, like `#[serde(flatten)]`.
-- [`sval_nested`](): Buffer `sval`'s flat [`Stream`]() API into a recursive one like `serde`'s. For types that `#[derive(Value)]`, the translation is non-allocating.
-- [`sval_ref`](): A variant of [`Value`]() for types that are internally borrowed (like `MyType<'a>`) instead of externally (like `&'a MyType`).
+- [`sval_fmt`](https://docs.rs/sval_json/2.14.1/sval_fmt/index.html): Colorized Rust-style debug formatting.
+- [`sval_json`](https://docs.rs/sval_json/2.14.1/sval_json/index.html): Serialize values as JSON in a `serde`-compatible format.
+- [`sval_protobuf`](https://docs.rs/sval_protobuf/latest/sval_protobuf/): Serialize values as protobuf messages.
+- [`sval_serde`](https://docs.rs/sval_json/2.14.1/sval_serde/index.html): Convert between `serde` and `sval`.
+- [`sval_buffer`](https://docs.rs/sval_json/2.14.1/sval_buffer/index.html): Losslessly buffers any [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html) into an owned, thread-safe variant.
+- [`sval_flatten`](https://docs.rs/sval_json/2.14.1/sval_flatten/index.html): Flatten the fields of a value onto its parent, like `#[serde(flatten)]`.
+- [`sval_nested`](https://docs.rs/sval_json/2.14.1/sval_nested/index.html): Buffer `sval`'s flat [`Stream`](https://docs.rs/sval/2.14.1/sval/trait.Stream.html) API into a recursive one like `serde`'s. For types that `#[derive(Value)]`, the translation is non-allocating.
+- [`sval_ref`](https://docs.rs/sval_json/2.14.1/sval_ref/index.html): A variant of [`Value`](https://docs.rs/sval/2.14.1/sval/trait.Value.html) for types that are internally borrowed (like `MyType<'a>`) instead of externally (like `&'a MyType`).

--- a/README.md
+++ b/README.md
@@ -4,48 +4,160 @@
 [![Latest version](https://img.shields.io/crates/v/sval.svg)](https://crates.io/crates/sval)
 [![Documentation Latest](https://docs.rs/sval/badge.svg)](https://docs.rs/sval)
 
-`sval` is a lightweight serialization-only framework that treats values like a flat stream of tokens.
-It's well suited to self-describing text formats like JSON.
+## What is it?
 
-## How is this different from `serde`?
+`sval` is a serialization-only framework for Rust. It has a simple, but expressive design that can express any Rust data
+structure, plus some it can't yet. It was originally designed as a niche framework for structured logging, targeting
+serialization to [JSON](), [protobuf](), and Rust's [Debug-style formatting](). The project has evolved beyond this point into a fully general
+and capable framework for introspecting runtime data.
 
-`serde` is the de-facto serialization framework for Rust and is well suited to the majority of
-use cases. `sval` is like a light blend of `serde::ser` and `serde::de` that is smaller in scope.
-It makes a few key different design decisions than `serde` that make it effective for working with
-self-describing formats:
+The core of `sval` is the [`Stream`]() trait. It defines the data model and features of the framework. `sval` makes
+a few different API design decisions compared to [`serde`](), the de-facto choice, to better accommodate the needs of Rust diagnostic frameworks:
 
-1. The API is flat rather than using recursion to stream nested datastructures.
-2. All values with dynamic sizes, including text strings, can be streamed in multiple calls.
-3. Borrowing is an optional optimization.
-4. The core data model is small, with tags for extensibility.
+1. **Simple API.** The [`Stream`]() trait has only a few required members that all values are forwarded to.
+   This makes it easy to write bespoke handling for specific data types without needing to implement unrelated methods.
+2. **`dyn`-friendly.** The [`Stream`]() trait is internally mutable, so is trivial to make `dyn`-compatible without intermediate boxing, making
+   it possible to use in no-std environments.
+3. **Buffer-friendly.** The [`Stream`]() trait is non-recursive, so values can be buffered as a flat stream of tokens and replayed later.
+4. **Borrowing as an optimization.** The [`Stream`]() trait may accept borrowed text or binary fragments for a specific lifetime `'sval`,
+   but is also required to accept temporary ones too. This makes it possible to optimize away allocations where possible, but still force
+   them if it's required.
+5. **Broadly compatible.** `sval` imposes very few constraints of its own, so it can trivially translate implementations of [`serde::Serialize`]()
+   into implementations of [`sval::Value`]().
 
-# Data-model
+`sval`'s data model takes inspiration from [CBOR](), specifically:
 
-- Values:
-    - `null`: the absence of any other meaningful value.
-    - Booleans: `true` and `false`.
-    - Text strings: stream of UTF8-encoded bytes.
-    - Binary strings: stream of arbtirary bytes.
-    - Numbers:
-        - Integers: `u8`-`u128`, `i8`-`i128`.
-        - Binary floating point: `f32`-`f64`.
-    - Maps: heterogeneous collection of key-value pairs.
-    - Sequences: heterogeneous collection of values.
-    - Tags: out-of-band type hints.
-    - Tagged values: a tag associated with a value.
-    - Records: tagged maps where keys are well-known labels.
-    - Tuples: tagged sequences.
-    - Enums: tagged variants, where variants are enums, tags, tagged values, records, or tuples.
+1. **Small core.** The base data model of `sval` is small. The required members of the [`Stream`]() trait only includes nulls, booleans,
+   text, 64-bit signed integers, 64-bit floating point numbers, and sequences. All other types, like arbitrary-precision floating point numbers,
+   records, and tuples, are representable in the base data model.
+2. **Extensible tags.** Users can define _tags_ that extend `sval`'s data model with new semantics. Examples of tags include Rust's `Some` and `None`
+   variants, constant-sized arrays, text that doesn't require JSON escaping, and anything else you might need.
 
-`sval` includes built-in tags that extend its data-model with some common datatypes:
+## Getting started
 
-- Rust primitives:
-    - `()`.
-    - `Option<T>`.
-- Arbitrary-precision decimal floating point numbers.
+Add `sval` to your `Cargo.toml`:
 
-Other built-in tags may be added in the future. Libraries may also define their own tags.
+```toml
+[dependencies.sval]
+version = "2.14.1"
+features = ["derive"]
+```
 
-## Current status
+Derive [`Value`]() on your Rust types, just like you do with `serde`:
 
-This project has a complete and stable API, but isn't well documented yet.
+```rust
+#[derive(sval::Value)]
+pub struct MyRecord<'a> {
+    field_0: i32,
+    field_1: bool,
+    field_2: &'a str,
+}
+```
+
+Types that derive or implement [`Value`]() can be streamed through an isntance of [`Stream`](). [`sval_json`]() is an example of a stream that
+serializes values to JSON:
+
+```toml
+[dependencies.sval_json]
+version = "2.14.1"
+features = ["std"]
+```
+
+```rust
+let my_record = MyRecord {
+    field_0: 1,
+    field_1: true,
+    field_2: "some text",
+};
+
+// {"field_0":1,"field_1":true,"field_2":"some text"}
+let json = sval_json::stream_to_string(my_record);
+```
+
+[`Stream`]()s can do more than just serialize data into an interchange format. [`sval_buffer`]() is a stream that buffers temporary values into owned,
+thread-safe ones. [`sval_flatten`]() is a stream that removes a level of nesting from a field. The [`Value`]() trait's conversion methods,
+like [`Value::to_text`](), are streams that attempt to cast an arbitrary value to a concrete type in `sval`'s data model.
+
+Here's an example of a stream that attempts to extract a specific field of a value as an `i32`:
+
+```rust
+pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
+    struct Extract<'a> {
+        depth: usize,
+        field: &'a str,
+        matched_field: bool,
+        extracted: Option<i32>,
+    }
+
+    impl<'a, 'sval> sval::Stream<'sval> for Extract<'a> {
+        fn record_value_begin(&mut self, _: Option<&sval::Tag>, label: &sval::Label) -> sval::Result {
+            self.matched_field = label.as_str() == self.field;
+            Ok(())
+        }
+
+        fn record_value_end(&mut self, _: Option<&sval::Tag>, _: &sval::Label) -> sval::Result {
+            Ok(())
+        }
+
+        fn i64(&mut self, v: i64) -> sval::Result {
+            if self.matched_field {
+                self.extracted = v.try_into().ok();
+            }
+
+            Ok(())
+        }
+
+        fn null(&mut self) -> sval::Result {
+            Ok(())
+        }
+    
+        fn bool(&mut self, _: bool) -> sval::Result {
+            Ok(())
+        }
+    
+        fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+            Ok(())
+        }
+    
+        fn text_fragment_computed(&mut self, _: &str) -> sval::Result {
+            Ok(())
+        }
+    
+        fn text_end(&mut self) -> sval::Result {
+            Ok(())
+        }
+    
+        fn f64(&mut self, _: f64) -> sval::Result {
+            Ok(())
+        }
+    
+        fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+            self.depth += 1;
+            Ok(())
+        }
+    
+        fn seq_value_begin(&mut self) -> sval::Result {
+            Ok(())
+        }
+    
+        fn seq_value_end(&mut self) -> sval::Result {
+            Ok(())
+        }
+    
+        fn seq_end(&mut self) -> sval::Result {
+            self.depth -= 1;
+            Ok(())
+        }
+    }
+
+    let mut stream = Extract {
+        depth: 0,
+        field,
+        matched_field: false,
+        extracted: None,
+    };
+    
+    sval::stream(&mut stream, &value).ok()?;
+    stream.extracted
+}
+```

--- a/README.md
+++ b/README.md
@@ -377,9 +377,9 @@ pub fn to_text(value: &(impl Value + ?Sized)) -> Option<&str> {
 
         // `text_fragment` accepts a string borrowed for `'sval`.
         //
-        // Implementations of `Value` will send borrowed data if they can
+        // Implementations of `Value` will send borrowed data if they can.
         fn text_fragment(&mut self, fragment: &'sval str) -> Result {
-            // Allow either independent strings, or fragments of a single borrowed string
+            // Allow either independent strings, or fragments of a single borrowed string.
             if !self.seen_fragment {
                 self.extracted = Some(fragment);
                 self.seen_fragment = true;
@@ -907,9 +907,9 @@ Enum::<i32>
 ```rust
 stream.enum_begin(None, Some(&sval::Label::new("Enum")), None)?;
 
-stream.tagged_begin(None, None, Some(&sval::Index::new(1)))?;
+stream.tagged_begin(None, None, None)?;
 stream.i64(1)?;
-stream.tagged_end(None, None, Some(&sval::Index::new(1)))?;
+stream.tagged_end(None, None, None)?;
 
 stream.enum_end(None, Some(&sval::Label::new("Enum")), None)?;
 ```
@@ -967,13 +967,13 @@ Enum::Inner::Tagged(i64)
 ```rust
 stream.enum_begin(None, Some(&sval::Label::new("Enum")), None)?;
 
-stream.enum_begin(None, Some(&sval::Label::new("Tagged")), Some(&sval::Index::new(0)))?;
+stream.enum_begin(None, Some(&sval::Label::new("Inner")), Some(&sval::Index::new(0)))?;
 
-stream.tagged_begin(None, None, Some(&sval::Index::new(1)))?;
+stream.tagged_begin(None, Some(&sval::Label::new("Tagged")), Some(&sval::Index::new(1)))?;
 stream.i64(1)?;
-stream.tagged_end(None, None, Some(&sval::Index::new(1)))?;
+stream.tagged_end(None, Some(&sval::Label::new("Tagged")), Some(&sval::Index::new(1)))?;
 
-stream.enum_end(None, Some(&sval::Label::new("Tagged")), Some(&sval::Index::new(0)))?;
+stream.enum_end(None, Some(&sval::Label::new("Inner")), Some(&sval::Index::new(0)))?;
 
 stream.enum_end(None, Some(&sval::Label::new("Enum")), None)?;
 ```

--- a/buffer/src/value.rs
+++ b/buffer/src/value.rs
@@ -635,15 +635,8 @@ impl<'sval> sval::Stream<'sval> for ValueBuf<'sval> {
         })
     }
 
-    fn tag_hint(
-        &mut self,
-        tag: &sval::Tag,
-    ) -> sval::Result {
-        self.try_catch(|buf| {
-            buf.push_kind(ValueKind::TagHint {
-                tag: tag.clone(),
-            })
-        })
+    fn tag_hint(&mut self, tag: &sval::Tag) -> sval::Result {
+        self.try_catch(|buf| buf.push_kind(ValueKind::TagHint { tag: tag.clone() }))
     }
 
     fn record_begin(
@@ -969,8 +962,10 @@ impl<'sval> ValueBuf<'sval> {
             | ValueKind::F64(_)
             | ValueKind::Text(_)
             | ValueKind::Binary(_)
-            | ValueKind::Tag { .. } 
-            | ValueKind::TagHint { .. } => return Err(Error::invalid_value("can't end at this index")),
+            | ValueKind::Tag { .. }
+            | ValueKind::TagHint { .. } => {
+                return Err(Error::invalid_value("can't end at this index"))
+            }
         } = len;
 
         Ok(())

--- a/examples/extract_field.rs
+++ b/examples/extract_field.rs
@@ -1,0 +1,103 @@
+#[macro_use]
+extern crate sval_derive_macros;
+
+pub fn get_i32<'sval>(field: &str, value: impl sval::Value) -> Option<i32> {
+    struct Extract<'a> {
+        depth: usize,
+        field: &'a str,
+        matched_field: bool,
+        extracted: Option<i32>,
+    }
+
+    impl<'a, 'sval> sval::Stream<'sval> for Extract<'a> {
+        fn record_value_begin(
+            &mut self,
+            _: Option<&sval::Tag>,
+            label: &sval::Label,
+        ) -> sval::Result {
+            self.matched_field = label.as_str() == self.field;
+            Ok(())
+        }
+
+        fn record_value_end(&mut self, _: Option<&sval::Tag>, _: &sval::Label) -> sval::Result {
+            Ok(())
+        }
+
+        fn i64(&mut self, v: i64) -> sval::Result {
+            if self.matched_field {
+                self.extracted = v.try_into().ok();
+            }
+
+            Ok(())
+        }
+
+        fn null(&mut self) -> sval::Result {
+            Ok(())
+        }
+
+        fn bool(&mut self, _: bool) -> sval::Result {
+            Ok(())
+        }
+
+        fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+            Ok(())
+        }
+
+        fn text_fragment_computed(&mut self, _: &str) -> sval::Result {
+            Ok(())
+        }
+
+        fn text_end(&mut self) -> sval::Result {
+            Ok(())
+        }
+
+        fn f64(&mut self, _: f64) -> sval::Result {
+            Ok(())
+        }
+
+        fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+            self.depth += 1;
+
+            Ok(())
+        }
+
+        fn seq_value_begin(&mut self) -> sval::Result {
+            Ok(())
+        }
+
+        fn seq_value_end(&mut self) -> sval::Result {
+            Ok(())
+        }
+
+        fn seq_end(&mut self) -> sval::Result {
+            self.depth -= 1;
+
+            Ok(())
+        }
+    }
+
+    let mut stream = Extract {
+        depth: 0,
+        field,
+        matched_field: false,
+        extracted: None,
+    };
+
+    sval::stream(&mut stream, &value).ok()?;
+    stream.extracted
+}
+
+#[derive(Value)]
+struct MyData {
+    field_0: bool,
+    field_1: i32,
+}
+
+fn main() {
+    let data = MyData {
+        field_0: true,
+        field_1: 42,
+    };
+
+    assert_eq!(Some(42), get_i32("field_1", data));
+}

--- a/examples/stream/simple.rs
+++ b/examples/stream/simple.rs
@@ -16,11 +16,6 @@ impl<'sval> sval::Stream<'sval> for MyStream {
         Ok(())
     }
 
-    fn f64(&mut self, v: f64) -> sval::Result {
-        print!("{}", v);
-        Ok(())
-    }
-
     fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
         print!("\"");
         Ok(())

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -87,11 +87,6 @@ impl<'sval> sval::Stream<'sval> for MyStream {
         Ok(())
     }
 
-    fn f64(&mut self, v: f64) -> sval::Result {
-        print!("{}", v);
-        Ok(())
-    }
-
     fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
         print!("\"");
         Ok(())

--- a/flatten/src/flattener.rs
+++ b/flatten/src/flattener.rs
@@ -499,14 +499,8 @@ impl<'sval, S: Flatten<'sval>> Stream<'sval> for Flattener<'sval, S> {
     }
 
     #[inline]
-    fn tag_hint(
-        &mut self,
-        tag: &Tag,
-    ) -> sval::Result {
-        self.value(
-            |buf| buf.tag_hint(tag),
-            |stream| stream.tag_hint(tag),
-        )
+    fn tag_hint(&mut self, tag: &Tag) -> sval::Result {
+        self.value(|buf| buf.tag_hint(tag), |stream| stream.tag_hint(tag))
     }
 
     #[inline]

--- a/flatten/src/label.rs
+++ b/flatten/src/label.rs
@@ -114,7 +114,7 @@ impl<'sval> LabelBuf<'sval> {
             LabelBuf::Text(text) => f(&Label::new_computed(text.as_str())),
             LabelBuf::I128(v) => {
                 let mut buf = itoa::Buffer::new();
-                let r= f(&Label::new_computed(buf.format(*v)));
+                let r = f(&Label::new_computed(buf.format(*v)));
                 r
             }
             LabelBuf::U128(v) => {
@@ -124,7 +124,7 @@ impl<'sval> LabelBuf<'sval> {
             }
             LabelBuf::F64(v) => {
                 let mut buf = ryu::Buffer::new();
-                let r =f(&Label::new_computed(buf.format(*v)));
+                let r = f(&Label::new_computed(buf.format(*v)));
                 r
             }
         }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["encoding", "no-std"]
 features = ["std"]
 
 [features]
-std = ["alloc", "serde/std", "sval/std", "sval_nested/std"]
-alloc = ["serde/alloc", "sval/alloc", "sval_nested/alloc"]
+std = ["alloc", "serde_core/std", "sval/std", "sval_nested/std"]
+alloc = ["serde_core/alloc", "sval/alloc", "sval_nested/alloc"]
 
 [dependencies.sval]
 version = "2.14.1"
@@ -27,6 +27,6 @@ version = "2.14.1"
 path = "../nested"
 default-features = false
 
-[dependencies.serde]
+[dependencies.serde_core]
 version = "1"
 default-features = false

--- a/serde/src/to_serialize.rs
+++ b/serde/src/to_serialize.rs
@@ -1,13 +1,13 @@
-use serde::ser::{Error as _, Serialize as _};
+use serde_core::ser::{Error as _, Serialize as _};
 
 use sval_nested::{
     Stream, StreamEnum, StreamMap, StreamRecord, StreamSeq, StreamTuple, Unsupported,
 };
 
 /**
-Serialize an [`sval::Value`] into a [`serde::Serializer`].
+Serialize an [`sval::Value`] into a [`serde_core::Serializer`].
 */
-pub fn serialize<S: serde::Serializer>(
+pub fn serialize<S: serde_core::Serializer>(
     serializer: S,
     value: impl sval::Value,
 ) -> Result<S::Ok, S::Error> {
@@ -15,14 +15,14 @@ pub fn serialize<S: serde::Serializer>(
 }
 
 /**
-Adapt an [`sval::Value`] into a [`serde::Serialize`].
+Adapt an [`sval::Value`] into a [`serde_core::Serialize`].
 */
 #[repr(transparent)]
 pub struct ToSerialize<V: ?Sized>(V);
 
 impl<V: sval::Value> ToSerialize<V> {
     /**
-    Adapt an [`sval::Value`] into a [`serde::Serialize`].
+    Adapt an [`sval::Value`] into a [`serde_core::Serialize`].
     */
     pub const fn new(value: V) -> ToSerialize<V> {
         ToSerialize(value)
@@ -31,7 +31,7 @@ impl<V: sval::Value> ToSerialize<V> {
 
 impl<V: sval::Value + ?Sized> ToSerialize<V> {
     /**
-    Adapt a reference to an [`sval::Value`] into a [`serde::Serialize`].
+    Adapt a reference to an [`sval::Value`] into a [`serde_core::Serialize`].
     */
     pub const fn new_borrowed<'a>(value: &'a V) -> &'a ToSerialize<V> {
         // SAFETY: `&'a V` and `&'a ToSerialize<V>` have the same ABI
@@ -39,8 +39,8 @@ impl<V: sval::Value + ?Sized> ToSerialize<V> {
     }
 }
 
-impl<V: sval::Value> serde::Serialize for ToSerialize<V> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl<V: sval::Value> serde_core::Serialize for ToSerialize<V> {
+    fn serialize<S: serde_core::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         Serializer::new(serializer)
             .value_ref(&self.0)
             .unwrap_or_else(|e| Err(S::Error::custom(e)))
@@ -91,7 +91,7 @@ impl<S> Serializer<S> {
     }
 }
 
-impl<'sval, S: serde::Serializer> Stream<'sval> for Serializer<S> {
+impl<'sval, S: serde_core::Serializer> Stream<'sval> for Serializer<S> {
     type Ok = Result<S::Ok, S::Error>;
 
     type Seq = SerializeSeq<S::SerializeSeq, S::Error>;
@@ -307,7 +307,7 @@ impl<'sval, S: serde::Serializer> Stream<'sval> for Serializer<S> {
     }
 }
 
-impl<'sval, S: serde::ser::SerializeSeq> StreamSeq<'sval> for SerializeSeq<S, S::Error> {
+impl<'sval, S: serde_core::ser::SerializeSeq> StreamSeq<'sval> for SerializeSeq<S, S::Error> {
     type Ok = Result<S::Ok, S::Error>;
 
     fn value_computed<V: sval::Value>(&mut self, value: V) -> sval_nested::Result {
@@ -333,7 +333,7 @@ impl<'sval, S: serde::ser::SerializeSeq> StreamSeq<'sval> for SerializeSeq<S, S:
     }
 }
 
-impl<'sval, S: serde::ser::SerializeMap> StreamMap<'sval> for SerializeMap<S, S::Error> {
+impl<'sval, S: serde_core::ser::SerializeMap> StreamMap<'sval> for SerializeMap<S, S::Error> {
     type Ok = Result<S::Ok, S::Error>;
 
     fn key_computed<V: sval::Value>(&mut self, key: V) -> sval_nested::Result {
@@ -378,8 +378,8 @@ impl<
         'sval,
         TOk,
         TError,
-        TNamed: serde::ser::SerializeStruct<Ok = TOk, Error = TError>,
-        TUnnamed: serde::ser::SerializeTuple<Ok = TOk, Error = TError>,
+        TNamed: serde_core::ser::SerializeStruct<Ok = TOk, Error = TError>,
+        TUnnamed: serde_core::ser::SerializeTuple<Ok = TOk, Error = TError>,
     > StreamRecord<'sval> for SerializeRecord<TNamed, TUnnamed, TError>
 {
     type Ok = Result<TOk, TError>;
@@ -432,8 +432,8 @@ impl<
         'sval,
         TOk,
         TError,
-        TNamed: serde::ser::SerializeTupleStruct<Ok = TOk, Error = TError>,
-        TUnnamed: serde::ser::SerializeTuple<Ok = TOk, Error = TError>,
+        TNamed: serde_core::ser::SerializeTupleStruct<Ok = TOk, Error = TError>,
+        TUnnamed: serde_core::ser::SerializeTuple<Ok = TOk, Error = TError>,
     > StreamTuple<'sval> for SerializeTuple<TNamed, TUnnamed, TError>
 {
     type Ok = Result<TOk, TError>;
@@ -478,7 +478,7 @@ impl<
     }
 }
 
-impl<'sval, S: serde::Serializer> StreamEnum<'sval> for SerializeEnum<S> {
+impl<'sval, S: serde_core::Serializer> StreamEnum<'sval> for SerializeEnum<S> {
     type Ok = Result<S::Ok, S::Error>;
 
     type Tuple = SerializeTupleVariant<S::SerializeTupleVariant, S::Error>;
@@ -612,7 +612,7 @@ impl<'sval, S: serde::Serializer> StreamEnum<'sval> for SerializeEnum<S> {
     }
 }
 
-impl<'sval, S: serde::ser::SerializeStructVariant> StreamRecord<'sval>
+impl<'sval, S: serde_core::ser::SerializeStructVariant> StreamRecord<'sval>
     for SerializeRecordVariant<S, S::Error>
 {
     type Ok = Result<S::Ok, S::Error>;
@@ -649,7 +649,7 @@ impl<'sval, S: serde::ser::SerializeStructVariant> StreamRecord<'sval>
     }
 }
 
-impl<'sval, S: serde::ser::SerializeTupleVariant> StreamTuple<'sval>
+impl<'sval, S: serde_core::ser::SerializeTupleVariant> StreamTuple<'sval>
     for SerializeTupleVariant<S, S::Error>
 {
     type Ok = Result<S::Ok, S::Error>;

--- a/serde/src/to_value.rs
+++ b/serde/src/to_value.rs
@@ -1,35 +1,35 @@
 use core::fmt;
 
-use serde::ser::Error as _;
+use serde_core::ser::Error as _;
 
 /**
-Stream a [`serde::Serialize`] into an [`sval::Stream`].
+Stream a [`serde_core::Serialize`] into an [`sval::Stream`].
 */
 pub fn stream<'sval>(
     stream: &mut (impl sval::Stream<'sval> + ?Sized),
-    value: impl serde::Serialize,
+    value: impl serde_core::Serialize,
 ) -> sval::Result {
     stream.value_computed(&ToValue::new(value))
 }
 
 /**
-Adapt a [`serde::Serialize`] into a [`sval::Value`].
+Adapt a [`serde_core::Serialize`] into a [`sval::Value`].
 */
 #[repr(transparent)]
 pub struct ToValue<V: ?Sized>(V);
 
-impl<V: serde::Serialize> ToValue<V> {
+impl<V: serde_core::Serialize> ToValue<V> {
     /**
-    Adapt a [`serde::Serialize`] into a [`sval::Value`].
+    Adapt a [`serde_core::Serialize`] into a [`sval::Value`].
     */
     pub const fn new(value: V) -> ToValue<V> {
         ToValue(value)
     }
 }
 
-impl<V: serde::Serialize + ?Sized> ToValue<V> {
+impl<V: serde_core::Serialize + ?Sized> ToValue<V> {
     /**
-    Adapt a reference to a [`serde::Serialize`] into an [`sval::Value`].
+    Adapt a reference to a [`serde_core::Serialize`] into an [`sval::Value`].
     */
     pub const fn new_borrowed<'a>(value: &'a V) -> &'a ToValue<V> {
         // SAFETY: `&'a V` and `&'a ToValue<V>` have the same ABI
@@ -37,7 +37,7 @@ impl<V: serde::Serialize + ?Sized> ToValue<V> {
     }
 }
 
-impl<V: serde::Serialize> sval::Value for ToValue<V> {
+impl<V: serde_core::Serialize> sval::Value for ToValue<V> {
     fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
         self.0.serialize(Stream { stream })?;
 
@@ -96,7 +96,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl serde::ser::Error for Error {
+impl serde_core::ser::Error for Error {
     fn custom<T>(_: T) -> Self
     where
         T: fmt::Display,
@@ -105,7 +105,7 @@ impl serde::ser::Error for Error {
     }
 }
 
-impl serde::ser::StdError for Error {}
+impl serde_core::ser::StdError for Error {}
 
 impl<'sval, S: sval::Stream<'sval>> Stream<S> {
     fn stream_value(&mut self, v: impl sval::Value) -> Result<(), Error> {
@@ -115,7 +115,7 @@ impl<'sval, S: sval::Stream<'sval>> Stream<S> {
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::Serializer for Stream<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::Serializer for Stream<S> {
     type Ok = ();
     type Error = Error;
 
@@ -205,7 +205,7 @@ impl<'sval, S: sval::Stream<'sval>> serde::Serializer for Stream<S> {
 
     fn serialize_some<T: ?Sized>(mut self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream_value(Some(ToValue(value)))
     }
@@ -247,7 +247,7 @@ impl<'sval, S: sval::Stream<'sval>> serde::Serializer for Stream<S> {
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .tagged_begin(None, Some(&sval::Label::new(name)), None)
@@ -268,7 +268,7 @@ impl<'sval, S: sval::Stream<'sval>> serde::Serializer for Stream<S> {
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .enum_begin(None, Some(&sval::Label::new(name)), None)
@@ -410,13 +410,13 @@ impl<'sval, S: sval::Stream<'sval>> serde::Serializer for Stream<S> {
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeSeq for Stream<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::ser::SerializeSeq for Stream<S> {
     type Ok = ();
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .seq_value_begin()
@@ -436,13 +436,13 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeSeq for Stream<S> {
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeTuple for StreamTuple<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::ser::SerializeTuple for StreamTuple<S> {
     type Ok = ();
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .tuple_value_begin(None, &sval::Index::new(self.index))
@@ -466,13 +466,13 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeTuple for StreamTuple<S
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeTupleStruct for StreamTuple<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::ser::SerializeTupleStruct for StreamTuple<S> {
     type Ok = ();
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .tuple_value_begin(None, &sval::Index::new(self.index))
@@ -496,13 +496,15 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeTupleStruct for StreamT
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeTupleVariant for StreamTupleVariant<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::ser::SerializeTupleVariant
+    for StreamTupleVariant<S>
+{
     type Ok = ();
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .tuple_value_begin(None, &sval::Index::new(self.index))
@@ -529,13 +531,13 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeTupleVariant for Stream
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeMap for Stream<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::ser::SerializeMap for Stream<S> {
     type Ok = ();
     type Error = Error;
 
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .map_key_begin()
@@ -550,7 +552,7 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeMap for Stream<S> {
 
     fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .map_value_begin()
@@ -570,7 +572,7 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeMap for Stream<S> {
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeStruct for StreamRecord<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::ser::SerializeStruct for StreamRecord<S> {
     type Ok = ();
     type Error = Error;
 
@@ -580,7 +582,7 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeStruct for StreamRecord
         value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .record_value_begin(None, &sval::Label::new(key))
@@ -600,7 +602,9 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeStruct for StreamRecord
     }
 }
 
-impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeStructVariant for StreamRecordVariant<S> {
+impl<'sval, S: sval::Stream<'sval>> serde_core::ser::SerializeStructVariant
+    for StreamRecordVariant<S>
+{
     type Ok = ();
     type Error = Error;
 
@@ -610,7 +614,7 @@ impl<'sval, S: sval::Stream<'sval>> serde::ser::SerializeStructVariant for Strea
         value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: serde::Serialize,
+        T: serde_core::Serialize,
     {
         self.stream
             .record_value_begin(None, &sval::Label::new(key))

--- a/serde/test/lib.rs
+++ b/serde/test/lib.rs
@@ -47,7 +47,7 @@ enum Enum {
 }
 
 fn test_case(
-    v: (impl sval::Value + serde::Serialize),
+    v: impl sval::Value + serde::Serialize,
     serde: &[serde_test::Token],
     sval: &[sval_test::Token],
 ) {

--- a/src/data/number.rs
+++ b/src/data/number.rs
@@ -1,13 +1,9 @@
 use crate::{std::fmt, tags, Result, Stream, Value};
 
 macro_rules! stream_default {
-    ($($fi:ident => $i:ty, $fu:ident => $u:ty,)*) => {
+    ($($fi:ident => $i:ty,)*) => {
         $(
             pub(crate) fn $fi<'sval>(v: $i, stream: &mut (impl Stream<'sval> + ?Sized)) -> crate::Result {
-                stream_number(stream, v)
-            }
-
-            pub(crate) fn $fu<'sval>(v: $u, stream: &mut (impl Stream<'sval> + ?Sized)) -> crate::Result {
                 stream_number(stream, v)
             }
         )*
@@ -35,6 +31,7 @@ macro_rules! impl_value {
 stream_default!(
     stream_i128 => i128,
     stream_u128 => u128,
+    stream_f64 => f64,
 );
 
 impl_value!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,9 @@ Structured, streaming values.
 The source of that data could be some Rust object or parsed from some encoding.
 It's well suited to self-describing, text-based formats like JSON.
 
-# A note on docs
-
-Even though this library's API is stable, these docs themselves are still a
-work-in-progress.
-
 # Getting started
+
+For a complete introduction, see [the project readme](https://github.com/sval-rs/sval).
 
 Add `sval` to your `Cargo.toml`:
 
@@ -19,8 +16,8 @@ Add `sval` to your `Cargo.toml`:
 version = "2.14.1"
 ```
 
-By default, `sval` doesn't depend on Rust's standard library or integrate
-with its collection types. To include them, add the `alloc` or `std` features:
+By default, `sval` doesn't depend on Rust's standard library or integrate with its collection types.
+To include them, add the `alloc` or `std` Cargo features:
 
 ```toml
 [dependencies.sval]
@@ -28,20 +25,26 @@ version = "2.14.1"
 features = ["std"]
 ```
 
+`sval` provides procedural macros for deriving its traits.
+Add the `derive` Cargo feature to enable them:
+
+```toml
+[dependencies.sval]
+version = "2.14.1"
+features = ["derive"]
+```
+
 # The `Value` trait
 
-[`Value`] is a trait for data types to implement that surfaces their structure
-through visitors called _streams_. `Value` is like `serde`'s `Serialize`. It
-can also be used like `serde`'s `Deserialize`.
+[`Value`] is a trait for data types to implement that surfaces their structure through visitors called _streams_.
+`Value` is like `serde`'s `Serialize`. It can also be used like `serde`'s `Deserialize`.
 
-Many standard types in Rust implement the `Value` trait. It can be derived
-on your own types using the `sval_derive` library.
+Many standard types in Rust implement the `Value` trait. It can be derived on your own types using the `sval_derive` library.
 
 # The `Stream` trait
 
-[`Stream`] is a trait for data formats and visitors to implement that observes
-the structure of _values_. `Stream` is like `serde`'s `Serializer`. It can
-also be used like `serde`'s `Deserializer`.
+[`Stream`] is a trait for data formats and visitors to implement that observes the structure of _values_.
+`Stream` is like `serde`'s `Serializer`. It can also be used like `serde`'s `Deserializer`.
 
 # Data-model
 
@@ -53,30 +56,22 @@ also be used like `serde`'s `Deserializer`.
 - Binary blobs
 - Integers (`u8`-`u128`, `i8`-`i128`)
 - Binary floating points (`f32`-`f64`)
-- Maps
 - Sequences
+- Maps
+- Tags
+- Tagged values
 - Records
 - Tuples
 - Enums
-- Tags
 
 # Tags
 
 [`Tag`] is a type for extending `sval`'s data-model with new kinds of values.
-Rust's own `()` and `Option<T>` types are expressed as tags. Other examples of
-tags include text that encodes RFC3339 timestamps or RFC4122 UUIDs.
+Rust's own `()` and `Option<T>` types are expressed as tags.
+Other examples of tags include text that encodes RFC3339 timestamps or RFC4122 UUIDs.
 
-The [`tags`] module contains built-in tags. Other libraries may define their own tags too.
-
-# Buffering
-
-Complex or arbitrarily-sized values like strings, maps, and sequences can all be
-streamed as chunks across multiple calls to avoid intermediate buffering when it's not necessary.
-
-# Object safety
-
-The [`Value`] and [`Stream`] traits aren't object-safe themselves, but object-safe
-wrappers are provided by the `sval_dynamic` crate. This wrapper works in no-std.
+The [`tags`] module contains built-in tags.
+Other libraries may define their own tags too.
 */
 
 #![no_std]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2,6 +2,8 @@ use crate::{data, tags, Index, Label, Result, Tag, Value};
 
 /**
 A consumer of structured data.
+
+Each instance of a stream is expected to receive a single complete value.
 */
 pub trait Stream<'sval> {
     /**
@@ -20,21 +22,33 @@ pub trait Stream<'sval> {
 
     /**
     Stream null, the absence of any other meaningful value.
+
+    Null is a complete value.
     */
     fn null(&mut self) -> Result;
 
     /**
     Stream a boolean.
+
+    A boolean is complete values.
     */
     fn bool(&mut self, value: bool) -> Result;
 
     /**
     Start a UTF8 text string.
+
+    After this call, a stream expects a series of zero or more calls to [`Stream::text_fragment`] and [`Stream::text_fragment_computed`].
+    A call to [`Stream::text_end`] completes the value.
+
+    This method accepts a `num_bytes` hint, which hints the length of the text value in bytes.
+    If a value for `num_bytes` is provided, it must be accurate.
     */
     fn text_begin(&mut self, num_bytes: Option<usize>) -> Result;
 
     /**
     Stream a fragment of UTF8 text.
+
+    This method may only be called in the context of a text value, between a call to [`Stream::text_begin`] and [`Stream::text_end`].
     */
     #[inline]
     fn text_fragment(&mut self, fragment: &'sval str) -> Result {
@@ -43,16 +57,26 @@ pub trait Stream<'sval> {
 
     /**
     Stream a fragment of UTF8 text, borrowed for some arbitrarily short lifetime.
+
+    This method may only be called in the context of a text value, between a call to [`Stream::text_begin`] and [`Stream::text_end`].
     */
     fn text_fragment_computed(&mut self, fragment: &str) -> Result;
 
     /**
     Complete a UTF8 text string.
+
+    This method may only be called in the context of a text value, after a call to [`Stream::text_begin`].
     */
     fn text_end(&mut self) -> Result;
 
     /**
     Start a bitstring.
+
+    After this call, a stream expects a series of zero or more calls to [`Stream::binary_fragment`] and [`Stream::binary_fragment_computed`].
+    A call to [`Stream::binary_end`] completes the value.
+
+    This method accepts a `num_bytes` hint, which hints the length of the bitstring value in bytes.
+    If a value for `num_bytes` is provided, it must be accurate.
     */
     fn binary_begin(&mut self, num_bytes: Option<usize>) -> Result {
         default_stream::binary_begin(self, num_bytes)
@@ -60,6 +84,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream a fragment of a bitstring.
+
+    This method may only be called in the context of a bitstring value, between a call to [`Stream::binary_begin`] and [`Stream::binary_end`].
     */
     #[inline]
     fn binary_fragment(&mut self, fragment: &'sval [u8]) -> Result {
@@ -68,6 +94,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream a fragment of a bitstring, borrowed for some arbitrarily short lifetime.
+
+    This method may only be called in the context of a bitstring value, between a call to [`Stream::binary_begin`] and [`Stream::binary_end`].
     */
     fn binary_fragment_computed(&mut self, fragment: &[u8]) -> Result {
         default_stream::binary_fragment_computed(self, fragment)
@@ -75,6 +103,8 @@ pub trait Stream<'sval> {
 
     /**
     Complete a bitstring.
+
+    This method may only be called in the context of a bitstring value, after a call to [`Stream::binary_begin`].
     */
     #[inline]
     fn binary_end(&mut self) -> Result {
@@ -83,6 +113,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream an unsigned 8bit integer.
+
+    An integer is a complete value.
     */
     #[inline]
     fn u8(&mut self, value: u8) -> Result {
@@ -91,6 +123,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream an unsigned 16bit integer.
+
+    An integer is a complete value.
     */
     #[inline]
     fn u16(&mut self, value: u16) -> Result {
@@ -99,6 +133,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream an unsigned 32bit integer.
+
+    An integer is a complete value.
     */
     #[inline]
     fn u32(&mut self, value: u32) -> Result {
@@ -107,6 +143,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream an unsigned 64bit integer.
+
+    An integer is a complete value.
     */
     #[inline]
     fn u64(&mut self, value: u64) -> Result {
@@ -115,6 +153,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream an unsigned 128bit integer.
+
+    An integer is a complete value.
     */
     fn u128(&mut self, value: u128) -> Result {
         default_stream::u128(self, value)
@@ -122,6 +162,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream a signed 8bit integer.
+
+    An integer is a complete value.
     */
     #[inline]
     fn i8(&mut self, value: i8) -> Result {
@@ -130,6 +172,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream a signed 16bit integer.
+
+    An integer is a complete value.
     */
     #[inline]
     fn i16(&mut self, value: i16) -> Result {
@@ -138,6 +182,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream a signed 32bit integer.
+
+    An integer is a complete value.
     */
     #[inline]
     fn i32(&mut self, value: i32) -> Result {
@@ -146,11 +192,15 @@ pub trait Stream<'sval> {
 
     /**
     Stream a signed 64bit integer.
+
+    An integer is a complete value.
     */
     fn i64(&mut self, value: i64) -> Result;
 
     /**
     Stream a signed 128bit integer.
+
+    An integer is a complete value.
     */
     fn i128(&mut self, value: i128) -> Result {
         default_stream::i128(self, value)
@@ -158,6 +208,8 @@ pub trait Stream<'sval> {
 
     /**
     Stream a 32bit binary floating point number.
+
+    An integer is a complete value.
     */
     #[inline]
     fn f32(&mut self, value: f32) -> Result {
@@ -166,13 +218,30 @@ pub trait Stream<'sval> {
 
     /**
     Stream a 64bit binary floating point number.
+
+    An integer is a complete value.
     */
     fn f64(&mut self, value: f64) -> Result {
         default_stream::f64(self, value)
     }
 
     /**
-    Start a homogenous mapping of arbitrary keys to values.
+    Start a heterogeneous mapping of arbitrary keys to values.
+
+    After this call, a stream expects a series of zero or more map key-value pairs.
+    Each key-value pair is a sequence of the following calls:
+
+    1. [`Stream::map_key_begin`].
+    2. A complete value.
+    3. [`Stream::map_key_end`].
+    4. [`Stream::map_value_begin`].
+    5. A complete value.
+    6. [`Stream::map_value_end`].
+
+    A call to [`Stream::map_end`] completes the value.
+
+    This method accepts a `num_entries` hint, which hints the number of key-value pairs in the map.
+    If a value for `num_entries` is provided, it must be accurate.
     */
     #[inline]
     fn map_begin(&mut self, num_entries: Option<usize>) -> Result {
@@ -181,6 +250,11 @@ pub trait Stream<'sval> {
 
     /**
     Start a key in a key-value mapping.
+
+    This method may only be called in the context of a map value, after a call to [`Stream::map_begin`].
+    This call must be followed by a complete value, then a call to [`Stream::map_key_end`].
+    Map keys cannot be empty.
+    Each map key must be followed by a map value.
     */
     #[inline]
     fn map_key_begin(&mut self) -> Result {
@@ -189,6 +263,10 @@ pub trait Stream<'sval> {
 
     /**
     Complete a key in a key-value mapping.
+
+    This method may only be called in the context of a key in a map value, after a call to [`Stream::map_key_begin`].
+    Map keys cannot be empty.
+    Each map key must be followed by a map value.
     */
     #[inline]
     fn map_key_end(&mut self) -> Result {
@@ -197,6 +275,10 @@ pub trait Stream<'sval> {
 
     /**
     Start a value in a key-value mapping.
+
+    This method may only be called in the context of a map value, after a call to [`Stream::map_begin`].
+    This call must be followed by a complete value.
+    Map values cannot be empty.
     */
     #[inline]
     fn map_value_begin(&mut self) -> Result {
@@ -205,6 +287,9 @@ pub trait Stream<'sval> {
 
     /**
     Complete a value in a key-value mapping.
+
+    This method may only be called in the context of a value in a map value, after a call to [`Stream::map_value_begin`].
+    Map values cannot be empty.
     */
     #[inline]
     fn map_value_end(&mut self) -> Result {
@@ -212,7 +297,9 @@ pub trait Stream<'sval> {
     }
 
     /**
-    Complete a homogenous mapping of arbitrary keys to values.
+    Complete a heterogeneous mapping of arbitrary keys to values.
+
+    This method may only be called in the context of a map value, after a call to [`Stream::map_begin`].
     */
     #[inline]
     fn map_end(&mut self) -> Result {
@@ -220,27 +307,62 @@ pub trait Stream<'sval> {
     }
 
     /**
-    Start a homogenous sequence of values.
+    Start a heterogeneous sequence of values.
+
+    After this call, a stream expects a series of zero or more sequence elements.
+    Each element is a sequence of the following calls:
+
+    1. [`Stream::seq_value_begin`].
+    2. A complete value.
+    3. [`Stream::seq_value_end`].
+
+    A call to [`Stream::seq_end`] completes the value.
+
+    This method accepts a `num_entries` hint, which hints the number of elements in the sequence.
+    If a value for `num_entries` is provided, it must be accurate.
     */
     fn seq_begin(&mut self, num_entries: Option<usize>) -> Result;
 
     /**
     Start an individual value in a sequence.
+
+    This method may only be called in the context of a sequence value, after a call to [`Stream::seq_begin`].
+    This call must be followed by a complete value, then a call to [`Stream::seq_value_end`].
+    Sequence elements cannot be empty.
     */
     fn seq_value_begin(&mut self) -> Result;
 
     /**
     Complete an individual value in a sequence.
+
+    This method may only be called in the context of an element in a sequence value, after a call to [`Stream::seq_value_begin`].
+    Sequence elements cannot be empty.
     */
     fn seq_value_end(&mut self) -> Result;
 
     /**
-    Complete a homogenous sequence of values.
+    Complete a heterogeneous sequence of values.
+
+    This method may only be called in the context of a sequence value, after a call to [`Stream::seq_begin`].
     */
     fn seq_end(&mut self) -> Result;
 
     /**
     Start a variant in an enumerated type.
+
+    After this call, a stream expects a complete value as the enum variant.
+    An enum variant can be any type that accepts a [`Tag`], [`Label`], and [`Index`] parameter.
+    That includes:
+
+    - Tags ([`Stream::tag`]).
+    - Tagged values ([`Stream::tagged_begin`]).
+    - Records ([`Stream::record_begin`]).
+    - Tuples ([`Stream::tuple_begin`]).
+    - Enums ([`Stream::enum_begin`]).
+
+    Enum variants may be empty.
+
+    A call to [`Stream::enum_end`] completes the value.
     */
     #[inline]
     fn enum_begin(
@@ -254,6 +376,8 @@ pub trait Stream<'sval> {
 
     /**
     Complete a variant in an enumerated type.
+
+    This method may only be called in the context of an enum value, after a call to [`Stream::enum_begin`].
     */
     #[inline]
     fn enum_end(
@@ -268,7 +392,9 @@ pub trait Stream<'sval> {
     /**
     Start a tagged value.
 
-    Tagged values may be used as enum variants.
+    After this call, a stream expects a complete value.
+
+    A call to [`Stream::tagged_end`] completes the value.
     */
     #[inline]
     fn tagged_begin(
@@ -282,6 +408,8 @@ pub trait Stream<'sval> {
 
     /**
     Complete a tagged value.
+
+    This method may only be called in the context of a tagged value, after a call to [`Stream::tagged_begin`].
     */
     #[inline]
     fn tagged_end(
@@ -296,7 +424,7 @@ pub trait Stream<'sval> {
     /**
     Stream a standalone tag.
 
-    Standalone tags may be used as enum variants.
+    Standalone tags are complete values.
     */
     fn tag(&mut self, tag: Option<&Tag>, label: Option<&Label>, index: Option<&Index>) -> Result {
         default_stream::tag(self, tag, label, index)
@@ -312,9 +440,19 @@ pub trait Stream<'sval> {
     }
 
     /**
-    Start a record type.
+    Start a record.
 
-    Records may be used as enum variants.
+    After this call, a stream expects a series of zero or more record fields.
+    Each field is a sequence of the following calls:
+
+    1. [`Stream::record_value_begin`].
+    2. A complete value.
+    3. [`Stream::record_value_end`].
+
+    A call to [`Stream::record_end`] completes the value.
+
+    This method accepts a `num_entries` hint, which hints the number of fields in the record.
+    If a value for `num_entries` is provided, it must be accurate.
     */
     #[inline]
     fn record_begin(
@@ -329,6 +467,10 @@ pub trait Stream<'sval> {
 
     /**
     Start a field in a record.
+
+    This method may only be called in the context of a record value, after a call to [`Stream::record_begin`].
+    This call must be followed by a complete value, then a call to [`Stream::record_value_end`].
+    Record fields cannot be empty.
     */
     #[inline]
     fn record_value_begin(&mut self, tag: Option<&Tag>, label: &Label) -> Result {
@@ -337,6 +479,9 @@ pub trait Stream<'sval> {
 
     /**
     Complete a field in a record.
+
+    This method may only be called in the context of a field in a record value, after a call to [`Stream::record_value_begin`].
+    Record fields cannot be empty.
     */
     #[inline]
     fn record_value_end(&mut self, tag: Option<&Tag>, label: &Label) -> Result {
@@ -344,7 +489,9 @@ pub trait Stream<'sval> {
     }
 
     /**
-    Complete a record type.
+    Complete a record.
+
+    This method may only be called in the context of a record value, after a call to [`Stream::record_begin`].
     */
     #[inline]
     fn record_end(
@@ -357,9 +504,19 @@ pub trait Stream<'sval> {
     }
 
     /**
-    Start a tuple type.
+    Start a tuple.
 
-    Tuples may be used as enum variants.
+    After this call, a stream expects a series of zero or more tuple fields.
+    Each field is a sequence of the following calls:
+
+    1. [`Stream::tuple_value_begin`].
+    2. A complete value.
+    3. [`Stream::tuple_value_end`].
+
+    A call to [`Stream::tuple_end`] completes the value.
+
+    This method accepts a `num_entries` hint, which hints the number of fields in the tuple.
+    If a value for `num_entries` is provided, it must be accurate.
     */
     #[inline]
     fn tuple_begin(
@@ -374,6 +531,10 @@ pub trait Stream<'sval> {
 
     /**
     Start a field in a tuple.
+
+    This method may only be called in the context of a tuple value, after a call to [`Stream::tuple_begin`].
+    This call must be followed by a complete value, then a call to [`Stream::tuple_value_end`].
+    Tuple fields cannot be empty.
     */
     #[inline]
     fn tuple_value_begin(&mut self, tag: Option<&Tag>, index: &Index) -> Result {
@@ -382,6 +543,9 @@ pub trait Stream<'sval> {
 
     /**
     Complete a field in a tuple.
+
+    This method may only be called in the context of a field in a tuple value, after a call to [`Stream::tuple_value_begin`].
+    Tuple fields cannot be empty.
     */
     #[inline]
     fn tuple_value_end(&mut self, tag: Option<&Tag>, index: &Index) -> Result {
@@ -389,7 +553,9 @@ pub trait Stream<'sval> {
     }
 
     /**
-    Complete a tuple type.
+    Complete a tuple.
+
+    This method may only be called in the context of a tuple value, after a call to [`Stream::tuple_begin`].
     */
     #[inline]
     fn tuple_end(
@@ -403,6 +569,18 @@ pub trait Stream<'sval> {
 
     /**
     Begin a type that may be treated as either a record or a tuple.
+
+    After this call, a stream expects a series of zero or more record tuple fields.
+    Each field is a sequence of the following calls:
+
+    1. [`Stream::record_tuple_value_begin`].
+    2. A complete value.
+    3. [`Stream::record_tuple_value_end`].
+
+    A call to [`Stream::record_tuple_end`] completes the value.
+
+    This method accepts a `num_entries` hint, which hints the number of fields in the record tuple.
+    If a value for `num_entries` is provided, it must be accurate.
     */
     #[inline]
     fn record_tuple_begin(
@@ -417,6 +595,10 @@ pub trait Stream<'sval> {
 
     /**
     Begin a field in a type that may be treated as either a record or a tuple.
+
+    This method may only be called in the context of a record tuple value, after a call to [`Stream::record_tuple_begin`].
+    This call must be followed by a complete value, then a call to [`Stream::record_tuple_value_end`].
+    Record tuple fields cannot be empty.
     */
     #[inline]
     fn record_tuple_value_begin(
@@ -430,6 +612,9 @@ pub trait Stream<'sval> {
 
     /**
     Complete a field in a type that may be treated as either a record or a tuple.
+
+    This method may only be called in the context of a field in a record tuple value, after a call to [`Stream::record_tuple_value_begin`].
+    Record tuple fields cannot be empty.
     */
     #[inline]
     fn record_tuple_value_end(
@@ -443,6 +628,8 @@ pub trait Stream<'sval> {
 
     /**
     Complete a type that may be treated as either a record or a tuple.
+
+    This method may only be called in the context of a record tuple value, after a call to [`Stream::record_tuple_begin`].
     */
     #[inline]
     fn record_tuple_end(
@@ -1287,7 +1474,7 @@ pub mod default_stream {
     }
 
     /**
-    Start a homogenous mapping of arbitrary keys to values.
+    Start a heterogeneous mapping of arbitrary keys to values.
     */
     pub fn map_begin<'sval>(
         stream: &mut (impl Stream<'sval> + ?Sized),
@@ -1329,7 +1516,7 @@ pub mod default_stream {
     }
 
     /**
-    Complete a homogenous mapping of arbitrary keys to values.
+    Complete a heterogeneous mapping of arbitrary keys to values.
     */
     pub fn map_end<'sval>(stream: &mut (impl Stream<'sval> + ?Sized)) -> Result {
         stream.seq_end()
@@ -1441,7 +1628,7 @@ pub mod default_stream {
     }
 
     /**
-    Start a record type.
+    Start a record.
 
     Records may be used as enum variants.
     */
@@ -1494,7 +1681,7 @@ pub mod default_stream {
     }
 
     /**
-    Complete a record type.
+    Complete a record.
     */
     pub fn record_end<'sval>(
         stream: &mut (impl Stream<'sval> + ?Sized),
@@ -1507,7 +1694,7 @@ pub mod default_stream {
     }
 
     /**
-    Start a tuple type.
+    Start a tuple.
 
     Tuples may be used as enum variants.
     */
@@ -1551,7 +1738,7 @@ pub mod default_stream {
     }
 
     /**
-    Complete a tuple type.
+    Complete a tuple.
     */
     pub fn tuple_end<'sval>(
         stream: &mut (impl Stream<'sval> + ?Sized),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -167,7 +167,9 @@ pub trait Stream<'sval> {
     /**
     Stream a 64bit binary floating point number.
     */
-    fn f64(&mut self, value: f64) -> Result;
+    fn f64(&mut self, value: f64) -> Result {
+        default_stream::f64(self, value)
+    }
 
     /**
     Start a homogenous mapping of arbitrary keys to values.
@@ -1275,6 +1277,13 @@ pub mod default_stream {
     */
     pub fn f32<'sval>(stream: &mut (impl Stream<'sval> + ?Sized), value: f32) -> Result {
         stream.f64(value as f64)
+    }
+
+    /**
+    Stream a 64bit binary floating point number.
+    */
+    pub fn f64<'sval>(stream: &mut (impl Stream<'sval> + ?Sized), value: f64) -> Result {
+        data::stream_f64(value, stream)
     }
 
     /**

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,6 +2,8 @@ use crate::{Index, Label, Result, Stream, Tag};
 
 /**
 A producer of structured data.
+
+Each call to [`Value::stream`] is expected to produce a single complete value.
 */
 pub trait Value {
     /**

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -25,7 +25,9 @@ pub fn assert_tokens<'sval, V: sval::Value + ?Sized>(value: &'sval V, tokens: &[
             {
                 let mut dyn_stream = &mut TokenBuf::new();
 
-                value.stream(&mut dyn_stream as &mut dyn sval_dynamic::Stream<'sval>).unwrap();
+                value
+                    .stream(&mut dyn_stream as &mut dyn sval_dynamic::Stream<'sval>)
+                    .unwrap();
 
                 assert_eq!(
                     tokens,
@@ -35,7 +37,7 @@ pub fn assert_tokens<'sval, V: sval::Value + ?Sized>(value: &'sval V, tokens: &[
                     sval_fmt::stream_to_string(AsValue(dyn_stream.as_tokens()))
                 );
             }
-        },
+        }
         Err(_) => stream.fail::<V>(),
     }
 }


### PR DESCRIPTION
This PR fills in documentation for `sval`'s design and API. This has been long overdue. It'll take some time to really fill it all in. I'm going to focus mostly on documenting the data model and how to use the `Stream` trait first, because I think that's where the most subtlety is.