### PR TITLE
Use syn::Error in derive proc macro

### DIFF
--- a/.github/workflows/buffer.yml
+++ b/.github/workflows/buffer.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         working-directory: ./buffer

--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         working-directory: ./dynamic

--- a/.github/workflows/flatten.yml
+++ b/.github/workflows/flatten.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         working-directory: ./flatten

--- a/.github/workflows/nested.yml
+++ b/.github/workflows/nested.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         working-directory: ./nested

--- a/.github/workflows/ref.yml
+++ b/.github/workflows/ref.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         working-directory: ./ref

--- a/.github/workflows/serde.yml
+++ b/.github/workflows/serde.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         working-directory: ./serde

--- a/.github/workflows/sval.yml
+++ b/.github/workflows/sval.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         run: cargo check --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain add 1.68.0 --profile minimal
-          rustup default 1.68.0
+          rustup toolchain add 1.71.0 --profile minimal
+          rustup default 1.71.0
 
       - name: Check
         working-directory: ./test

--- a/derive/test/compile_fail/enum_dynamic_unindexed_variants.stderr
+++ b/derive/test/compile_fail/enum_dynamic_unindexed_variants.stderr
@@ -1,7 +1,7 @@
-error: proc-macro derive panicked
+error: dynamic enums don't have variants
  --> compile_fail/enum_dynamic_unindexed_variants.rs:3:10
   |
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: dynamic enums don't have variants
+  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/derive/test/compile_fail/enum_dynamic_unlabeled_variants.stderr
+++ b/derive/test/compile_fail/enum_dynamic_unlabeled_variants.stderr
@@ -1,7 +1,7 @@
-error: proc-macro derive panicked
+error: dynamic enums don't have variants
  --> compile_fail/enum_dynamic_unlabeled_variants.rs:3:10
   |
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: dynamic enums don't have variants
+  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/derive/test/compile_fail/enum_unindexed_fields.stderr
+++ b/derive/test/compile_fail/enum_unindexed_fields.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/enum_unindexed_fields.rs:3:10
+error: unsupported attribute `unindexed_fields` on enum
+ --> compile_fail/enum_unindexed_fields.rs:4:8
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported attribute `unindexed_fields` on enum
+4 | #[sval(unindexed_fields)]
+  |        ^^^^^^^^^^^^^^^^

--- a/derive/test/compile_fail/enum_unlabeled_fields.stderr
+++ b/derive/test/compile_fail/enum_unlabeled_fields.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/enum_unlabeled_fields.rs:3:10
+error: unsupported attribute `unlabeled_fields` on enum
+ --> compile_fail/enum_unlabeled_fields.rs:4:8
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported attribute `unlabeled_fields` on enum
+4 | #[sval(unlabeled_fields)]
+  |        ^^^^^^^^^^^^^^^^

--- a/derive/test/compile_fail/newtype_data_tag.stderr
+++ b/derive/test/compile_fail/newtype_data_tag.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/newtype_data_tag.rs:3:10
+error: unsupported attribute `data_tag` on newtype field
+ --> compile_fail/newtype_data_tag.rs:4:27
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported attribute `data_tag` on newtype field
+4 | pub struct Newtype(#[sval(data_tag = "sval::tags::NUMBER")] i32);
+  |                           ^^^^^^^^

--- a/derive/test/compile_fail/newtype_index.stderr
+++ b/derive/test/compile_fail/newtype_index.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/newtype_index.rs:3:10
+error: unsupported attribute `index` on newtype field
+ --> compile_fail/newtype_index.rs:4:27
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported attribute `index` on newtype field
+4 | pub struct Newtype(#[sval(index = 1)] i32);
+  |                           ^^^^^

--- a/derive/test/compile_fail/newtype_label.stderr
+++ b/derive/test/compile_fail/newtype_label.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/newtype_label.rs:3:10
+error: unsupported attribute `label` on newtype field
+ --> compile_fail/newtype_label.rs:4:27
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported attribute `label` on newtype field
+4 | pub struct Newtype(#[sval(label = "value")] i32);
+  |                           ^^^^^

--- a/derive/test/compile_fail/newtype_tag.stderr
+++ b/derive/test/compile_fail/newtype_tag.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/newtype_tag.rs:3:10
+error: unsupported attribute `tag` on newtype field
+ --> compile_fail/newtype_tag.rs:4:27
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported attribute `tag` on newtype field
+4 | pub struct Newtype(#[sval(tag = "sval::tags::NUMBER")] i32);
+  |                           ^^^

--- a/derive/test/compile_fail/record_as_seq_incomplete_indexes.stderr
+++ b/derive/test/compile_fail/record_as_seq_incomplete_indexes.stderr
@@ -1,7 +1,5 @@
 error: unsupported attribute `index` on struct field
- --> compile_fail/record_as_seq_incomplete_indexes.rs:3:10
+ --> compile_fail/record_as_seq_incomplete_indexes.rs:6:12
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)
+6 |     #[sval(index = 1)]
+  |            ^^^^^

--- a/derive/test/compile_fail/record_as_seq_incomplete_indexes.stderr
+++ b/derive/test/compile_fail/record_as_seq_incomplete_indexes.stderr
@@ -1,7 +1,7 @@
-error: proc-macro derive panicked
+error: unsupported attribute `index` on struct field
  --> compile_fail/record_as_seq_incomplete_indexes.rs:3:10
   |
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: unsupported attribute `index` on struct field
+  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/derive/test/compile_fail/record_as_seq_incomplete_labels.stderr
+++ b/derive/test/compile_fail/record_as_seq_incomplete_labels.stderr
@@ -1,7 +1,5 @@
 error: unsupported attribute `label` on struct field
- --> compile_fail/record_as_seq_incomplete_labels.rs:3:10
+ --> compile_fail/record_as_seq_incomplete_labels.rs:6:12
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)
+6 |     #[sval(label = "a")]
+  |            ^^^^^

--- a/derive/test/compile_fail/record_as_seq_incomplete_labels.stderr
+++ b/derive/test/compile_fail/record_as_seq_incomplete_labels.stderr
@@ -1,7 +1,7 @@
-error: proc-macro derive panicked
+error: unsupported attribute `label` on struct field
  --> compile_fail/record_as_seq_incomplete_labels.rs:3:10
   |
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: unsupported attribute `label` on struct field
+  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/derive/test/compile_fail/record_as_tuple_incomplete_labels.stderr
+++ b/derive/test/compile_fail/record_as_tuple_incomplete_labels.stderr
@@ -1,7 +1,5 @@
 error: unsupported attribute `label` on struct field
- --> compile_fail/record_as_tuple_incomplete_labels.rs:3:10
+ --> compile_fail/record_as_tuple_incomplete_labels.rs:6:12
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)
+6 |     #[sval(label = "a")]
+  |            ^^^^^

--- a/derive/test/compile_fail/record_as_tuple_incomplete_labels.stderr
+++ b/derive/test/compile_fail/record_as_tuple_incomplete_labels.stderr
@@ -1,7 +1,7 @@
-error: proc-macro derive panicked
+error: unsupported attribute `label` on struct field
  --> compile_fail/record_as_tuple_incomplete_labels.rs:3:10
   |
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: unsupported attribute `label` on struct field
+  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/derive/test/compile_fail/tuple_incomplete_labels.stderr
+++ b/derive/test/compile_fail/tuple_incomplete_labels.stderr
@@ -1,7 +1,7 @@
-error: proc-macro derive panicked
+error: if any fields have a label then all fields need one
  --> compile_fail/tuple_incomplete_labels.rs:3:10
   |
 3 | #[derive(Value)]
   |          ^^^^^
   |
-  = help: message: if any fields have a label then all fields need one
+  = note: this error originates in the derive macro `Value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/derive/test/compile_fail/tuple_transparent.stderr
+++ b/derive/test/compile_fail/tuple_transparent.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/tuple_transparent.rs:3:10
+error: unsupported attribute `transparent` on struct
+ --> compile_fail/tuple_transparent.rs:4:8
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported attribute `transparent` on struct
+4 | #[sval(transparent)]
+  |        ^^^^^^^^^^^

--- a/derive/test/compile_fail/union.stderr
+++ b/derive/test/compile_fail/union.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> compile_fail/union.rs:3:10
+error: unions are not supported for sval derive
+ --> compile_fail/union.rs:4:5
   |
-3 | #[derive(Value)]
-  |          ^^^^^
-  |
-  = help: message: unsupported container type
+4 | pub union Union {
+  |     ^^^^^

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -15,11 +15,14 @@ pub(crate) struct TagAttr;
 impl SvalAttribute for TagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
-            Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
-            Expr::Path(path) => Ok(Some(path.path.clone())),
-            _ => Ok(None),
+            Expr::Lit(lit) => Ok(self.from_lit(&lit.lit)?),
+            Expr::Path(path) => Ok(path.path.clone()),
+            _ => Err(syn::Error::new(
+                expr.span(),
+                "invalid `tag`: expected literal or path",
+            )),
         }
     }
 
@@ -56,11 +59,14 @@ pub(crate) struct DataTagAttr;
 impl SvalAttribute for DataTagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
-            Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
-            Expr::Path(path) => Ok(Some(path.path.clone())),
-            _ => Ok(None),
+            Expr::Lit(lit) => Ok(self.from_lit(&lit.lit)?),
+            Expr::Path(path) => Ok(path.path.clone()),
+            _ => Err(syn::Error::new(
+                expr.span(),
+                "invalid `data_tag`: expected literal or path",
+            )),
         }
     }
 
@@ -97,11 +103,14 @@ pub(crate) struct LabelAttr;
 impl SvalAttribute for LabelAttr {
     type Result = LabelValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
-            Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
-            Expr::Path(path) => Ok(Some(LabelValue::Ident(quote!(#path)))),
-            _ => Ok(None),
+            Expr::Lit(lit) => Ok(self.from_lit(&lit.lit)?),
+            Expr::Path(path) => Ok(LabelValue::Ident(quote!(#path))),
+            _ => Err(syn::Error::new(
+                expr.span(),
+                "invalid `label`: expected literal or path",
+            )),
         }
     }
 
@@ -150,23 +159,29 @@ impl IndexAttr {
 impl SvalAttribute for IndexAttr {
     type Result = IndexValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
             // Take `-` into account
             Expr::Unary(ExprUnary {
                 op: UnOp::Neg(_),
-                expr,
+                expr: inner_expr,
                 ..
             }) => {
-                if let Expr::Lit(ref lit) = **expr {
-                    Ok(Some(IndexValue::Const(-(self.const_from_lit(&lit.lit)?))))
+                if let Expr::Lit(ref lit) = **inner_expr {
+                    Ok(IndexValue::Const(-(self.const_from_lit(&lit.lit)?)))
                 } else {
-                    Ok(None)
+                    Err(syn::Error::new(
+                        inner_expr.span(),
+                        "invalid `index`: expected integer",
+                    ))
                 }
             }
-            Expr::Lit(lit) => Ok(Some(IndexValue::Const(self.const_from_lit(&lit.lit)?))),
-            Expr::Path(path) => Ok(Some(IndexValue::Ident(quote!(#path)))),
-            _ => Ok(None),
+            Expr::Lit(lit) => Ok(IndexValue::Const(self.const_from_lit(&lit.lit)?)),
+            Expr::Path(path) => Ok(IndexValue::Ident(quote!(#path))),
+            _ => Err(syn::Error::new(
+                expr.span(),
+                "invalid `index`: expected literal, path, or integer",
+            )),
         }
     }
 
@@ -416,11 +431,14 @@ pub(crate) trait RawAttribute {
 pub(crate) trait SvalAttribute: RawAttribute {
     type Result: 'static;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         if let Expr::Lit(lit) = expr {
-            Ok(Some(self.from_lit(&lit.lit)?))
+            Ok(self.from_lit(&lit.lit)?)
         } else {
-            Ok(None)
+            Err(syn::Error::new(
+                expr.span(),
+                format_args!("invalid {}: expected literal", self.key()),
+            ))
         }
     }
 
@@ -452,7 +470,7 @@ pub(crate) fn ensure_missing<T: SvalAttribute>(
 ) -> syn::Result<()> {
     let key = request.key().to_owned();
 
-    if get_unchecked::<T>(ctxt, request, attrs)?.is_some() {
+    if get::<T>(ctxt, request, attrs)?.is_some() {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
             format_args!("unsupported attribute `{}` on {}", key, ctxt),
@@ -462,6 +480,10 @@ pub(crate) fn ensure_missing<T: SvalAttribute>(
     Ok(())
 }
 
+/**
+Check the set of attributes, failing if any are duplicated, or aren't known or supported by
+the derive context.
+*/
 pub(crate) fn check(
     ctxt: &str,
     allowed: &[&dyn RawAttribute],
@@ -508,7 +530,13 @@ pub(crate) fn check(
     Ok(())
 }
 
-pub(crate) fn get_unchecked<T: SvalAttribute>(
+/**
+Get the value of an attribute, without checking the set itself for validity.
+
+This function will still fail if the requested attribute is invalid, but won't
+handle duplicates, which are expected to have been caught by an earlier call to `check`.
+*/
+pub(crate) fn get<T: SvalAttribute>(
     ctxt: &str,
     request: T,
     attrs: &[Attribute],
@@ -522,7 +550,7 @@ pub(crate) fn get_unchecked<T: SvalAttribute>(
 
         for (value_key, value) in meta {
             if value_key.is_ident(request_key) {
-                return request.try_from_expr(&value);
+                return Ok(Some(request.try_from_expr(&value)?));
             }
         }
     }

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -470,9 +470,9 @@ pub(crate) fn ensure_missing<T: SvalAttribute>(
 ) -> syn::Result<()> {
     let key = request.key().to_owned();
 
-    if get::<T>(ctxt, request, attrs)?.is_some() {
+    if let Some((unexpected, _)) = find(ctxt, request.key(), attrs)? {
         return Err(syn::Error::new(
-            proc_macro2::Span::call_site(),
+            unexpected.span(),
             format_args!("unsupported attribute `{}` on {}", key, ctxt),
         ));
     }
@@ -499,8 +499,8 @@ pub(crate) fn check(
         for (value_key, _) in meta {
             let mut is_valid_attr = false;
 
-            for attr in allowed {
-                let attr_key = attr.key();
+            for allowed in allowed {
+                let attr_key = allowed.key();
 
                 if value_key.is_ident(attr_key) {
                     is_valid_attr = true;
@@ -541,8 +541,14 @@ pub(crate) fn get<T: SvalAttribute>(
     request: T,
     attrs: &[Attribute],
 ) -> syn::Result<Option<T::Result>> {
-    let request_key = request.key();
+    let Some((_, value)) = find(ctxt, request.key(), attrs)? else {
+        return Ok(None);
+    };
 
+    Ok(Some(request.from_expr(&value)?))
+}
+
+fn find(ctxt: &str, request_key: &str, attrs: &[Attribute]) -> syn::Result<Option<(Path, Expr)>> {
     for attr in attrs {
         let Some(meta) = sval_attr(ctxt, attr)? else {
             continue;
@@ -550,7 +556,7 @@ pub(crate) fn get<T: SvalAttribute>(
 
         for (value_key, value) in meta {
             if value_key.is_ident(request_key) {
-                return Ok(Some(request.from_expr(&value)?));
+                return Ok(Some((value_key, value)));
             }
         }
     }

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use syn::{spanned::Spanned, Attribute, Error, Expr, ExprUnary, Lit, Path, Result, UnOp};
+use syn::{spanned::Spanned, Attribute, Expr, ExprUnary, Lit, Path, UnOp};
 
 use crate::{index::IndexValue, label::LabelValue};
 
@@ -15,7 +15,7 @@ pub(crate) struct TagAttr;
 impl SvalAttribute for TagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
         match expr {
             Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
             Expr::Path(path) => Ok(Some(path.path.clone())),
@@ -23,14 +23,17 @@ impl SvalAttribute for TagAttr {
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
-            Lit::Str(s) => s
-                .parse()
-                .map_err(|_| Error::new(s.span(), "invalid tag: expected valid path")),
-            _ => Err(Error::new(
+            Lit::Str(s) => s.parse().map_err(|e| {
+                let mut r = syn::Error::new(s.span(), "invalid `tag`: expected valid path");
+                r.combine(e);
+
+                r
+            }),
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid tag: expected string literal",
+                "invalid `tag`: expected string literal",
             )),
         }
     }
@@ -53,7 +56,7 @@ pub(crate) struct DataTagAttr;
 impl SvalAttribute for DataTagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
         match expr {
             Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
             Expr::Path(path) => Ok(Some(path.path.clone())),
@@ -61,14 +64,17 @@ impl SvalAttribute for DataTagAttr {
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
-            Lit::Str(s) => s
-                .parse()
-                .map_err(|_| Error::new(s.span(), "invalid data_tag: expected valid path")),
-            _ => Err(Error::new(
+            Lit::Str(s) => s.parse().map_err(|e| {
+                let mut r = syn::Error::new(s.span(), "invalid `data_tag`: expected valid path");
+                r.combine(e);
+
+                r
+            }),
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid data_tag: expected string literal",
+                "invalid `data_tag`: expected string literal",
             )),
         }
     }
@@ -91,7 +97,7 @@ pub(crate) struct LabelAttr;
 impl SvalAttribute for LabelAttr {
     type Result = LabelValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
         match expr {
             Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
             Expr::Path(path) => Ok(Some(LabelValue::Ident(quote!(#path)))),
@@ -99,12 +105,12 @@ impl SvalAttribute for LabelAttr {
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Str(s) => Ok(LabelValue::Const(s.value())),
-            _ => Err(Error::new(
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid label: expected string literal",
+                "invalid `label`: expected string literal",
             )),
         }
     }
@@ -125,12 +131,18 @@ to use for the annotated item.
 pub(crate) struct IndexAttr;
 
 impl IndexAttr {
-    fn const_from_lit(&self, lit: &Lit) -> Result<isize> {
+    fn const_from_lit(&self, lit: &Lit) -> syn::Result<isize> {
         match lit {
-            Lit::Int(n) => n
-                .base10_parse()
-                .map_err(|_| Error::new(n.span(), "invalid index: expected integer")),
-            _ => Err(Error::new(lit.span(), "invalid index: expected integer")),
+            Lit::Int(n) => n.base10_parse().map_err(|e| {
+                let mut r = syn::Error::new(n.span(), "invalid `index`: expected integer");
+                r.combine(e);
+
+                r
+            }),
+            _ => Err(syn::Error::new(
+                lit.span(),
+                "invalid `index`: expected integer",
+            )),
         }
     }
 }
@@ -138,7 +150,7 @@ impl IndexAttr {
 impl SvalAttribute for IndexAttr {
     type Result = IndexValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
         match expr {
             // Take `-` into account
             Expr::Unary(ExprUnary {
@@ -158,7 +170,7 @@ impl SvalAttribute for IndexAttr {
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         Ok(IndexValue::Const(self.const_from_lit(lit)?))
     }
 }
@@ -180,10 +192,13 @@ pub(crate) struct SkipAttr;
 impl SvalAttribute for SkipAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Bool(b) => Ok(b.value),
-            _ => Err(Error::new(lit.span(), "invalid skip: expected boolean")),
+            _ => Err(syn::Error::new(
+                lit.span(),
+                "invalid `skip`: expected boolean",
+            )),
         }
     }
 }
@@ -204,12 +219,12 @@ pub(crate) struct UnlabeledFieldsAttr;
 impl SvalAttribute for UnlabeledFieldsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Bool(b) => Ok(b.value),
-            _ => Err(Error::new(
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid unlabeled_fields: expected boolean",
+                "invalid `unlabeled_fields`: expected boolean",
             )),
         }
     }
@@ -231,12 +246,12 @@ pub(crate) struct UnindexedFieldsAttr;
 impl SvalAttribute for UnindexedFieldsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Bool(b) => Ok(b.value),
-            _ => Err(Error::new(
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid unindexed_fields: expected boolean",
+                "invalid `unindexed_fields`: expected boolean",
             )),
         }
     }
@@ -258,12 +273,12 @@ pub(crate) struct UnlabeledVariantsAttr;
 impl SvalAttribute for UnlabeledVariantsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Bool(b) => Ok(b.value),
-            _ => Err(Error::new(
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid unlabeled_variants: expected boolean",
+                "invalid `unlabeled_variants`: expected boolean",
             )),
         }
     }
@@ -285,12 +300,12 @@ pub(crate) struct UnindexedVariantsAttr;
 impl SvalAttribute for UnindexedVariantsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Bool(b) => Ok(b.value),
-            _ => Err(Error::new(
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid unindexed_variants: expected boolean",
+                "invalid `unindexed_variants`: expected boolean",
             )),
         }
     }
@@ -312,10 +327,13 @@ pub(crate) struct DynamicAttr;
 impl SvalAttribute for DynamicAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Bool(b) => Ok(b.value),
-            _ => Err(Error::new(lit.span(), "invalid dynamic: expected boolean")),
+            _ => Err(syn::Error::new(
+                lit.span(),
+                "invalid `dynamic`: expected boolean",
+            )),
         }
     }
 }
@@ -337,12 +355,12 @@ pub(crate) struct TransparentAttr;
 impl SvalAttribute for TransparentAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         match lit {
             Lit::Bool(b) => Ok(b.value),
-            _ => Err(Error::new(
+            _ => Err(syn::Error::new(
                 lit.span(),
-                "invalid transparent: expected boolean",
+                "invalid `transparent`: expected boolean",
             )),
         }
     }
@@ -364,12 +382,11 @@ pub(crate) struct FlattenAttr;
 impl SvalAttribute for FlattenAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result> {
         #[cfg(not(feature = "flatten"))]
         {
-            let _ = lit;
-            Err(Error::new(
-                proc_macro2::Span::call_site(),
+            Err(syn::Error::new(
+                lit.span(),
                 "the `flatten` attribute can only be used when the `flatten` Cargo feature of `sval_derive` is enabled",
             ))
         }
@@ -377,7 +394,10 @@ impl SvalAttribute for FlattenAttr {
         {
             match lit {
                 Lit::Bool(b) => Ok(b.value),
-                _ => Err(Error::new(lit.span(), "invalid flatten: expected boolean")),
+                _ => Err(syn::Error::new(
+                    lit.span(),
+                    "invalid `flatten`: expected boolean",
+                )),
             }
         }
     }
@@ -396,7 +416,7 @@ pub(crate) trait RawAttribute {
 pub(crate) trait SvalAttribute: RawAttribute {
     type Result: 'static;
 
-    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
+    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Option<Self::Result>> {
         if let Expr::Lit(lit) = expr {
             Ok(Some(self.from_lit(&lit.lit)?))
         } else {
@@ -404,21 +424,24 @@ pub(crate) trait SvalAttribute: RawAttribute {
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Result<Self::Result>;
+    fn from_lit(&self, lit: &Lit) -> syn::Result<Self::Result>;
 }
 
-pub(crate) fn ensure_empty(ctxt: &str, attrs: &[Attribute]) -> Result<()> {
+pub(crate) fn ensure_empty(ctxt: &str, attrs: &[Attribute]) -> syn::Result<()> {
     // Just ensure the attribute list is empty
-    for (value_key, _) in attrs
-        .iter()
-        .filter_map(|attr| sval_attr(ctxt, attr))
-        .flatten()
-    {
-        return Err(Error::new(
-            value_key.span(),
-            format_args!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt),
-        ));
+    for attr in attrs {
+        let Some(meta) = sval_attr(ctxt, attr)? else {
+            continue;
+        };
+
+        for (value_key, _) in meta {
+            return Err(syn::Error::new(
+                value_key.span(),
+                format_args!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt),
+            ));
+        }
     }
+
     Ok(())
 }
 
@@ -426,50 +449,62 @@ pub(crate) fn ensure_missing<T: SvalAttribute>(
     ctxt: &str,
     request: T,
     attrs: &[Attribute],
-) -> Result<()> {
+) -> syn::Result<()> {
     let key = request.key().to_owned();
 
     if get_unchecked::<T>(ctxt, request, attrs)?.is_some() {
-        return Err(Error::new(
+        return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
             format_args!("unsupported attribute `{}` on {}", key, ctxt),
         ));
     }
+
     Ok(())
 }
 
-pub(crate) fn check(ctxt: &str, allowed: &[&dyn RawAttribute], attrs: &[Attribute]) -> Result<()> {
+pub(crate) fn check(
+    ctxt: &str,
+    allowed: &[&dyn RawAttribute],
+    attrs: &[Attribute],
+) -> syn::Result<()> {
     let mut seen = HashSet::new();
 
-    for (value_key, _) in attrs
-        .iter()
-        .filter_map(|attr| sval_attr(ctxt, attr))
-        .flatten()
-    {
-        let mut is_valid_attr = false;
+    for attr in attrs {
+        let Some(meta) = sval_attr(ctxt, attr)? else {
+            continue;
+        };
 
-        for attr in allowed {
-            let attr_key = attr.key();
+        for (value_key, _) in meta {
+            let mut is_valid_attr = false;
 
-            if value_key.is_ident(attr_key) {
-                is_valid_attr = true;
+            for attr in allowed {
+                let attr_key = attr.key();
 
-                if !seen.insert(attr_key) {
-                    return Err(Error::new(
-                        value_key.span(),
-                        format_args!("duplicate attribute `{}` on {}", quote!(#value_key), ctxt),
-                    ));
+                if value_key.is_ident(attr_key) {
+                    is_valid_attr = true;
+
+                    if !seen.insert(attr_key) {
+                        return Err(syn::Error::new(
+                            value_key.span(),
+                            format_args!(
+                                "duplicate attribute `{}` on {}",
+                                quote!(#value_key),
+                                ctxt
+                            ),
+                        ));
+                    }
                 }
             }
-        }
 
-        if !is_valid_attr {
-            return Err(Error::new(
-                value_key.span(),
-                format_args!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt),
-            ));
+            if !is_valid_attr {
+                return Err(syn::Error::new(
+                    value_key.span(),
+                    format_args!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt),
+                ));
+            }
         }
     }
+
     Ok(())
 }
 
@@ -477,16 +512,18 @@ pub(crate) fn get_unchecked<T: SvalAttribute>(
     ctxt: &str,
     request: T,
     attrs: &[Attribute],
-) -> Result<Option<T::Result>> {
+) -> syn::Result<Option<T::Result>> {
     let request_key = request.key();
 
-    for (value_key, value) in attrs
-        .iter()
-        .filter_map(|attr| sval_attr(ctxt, attr))
-        .flatten()
-    {
-        if value_key.is_ident(request_key) {
-            return request.try_from_expr(&value);
+    for attr in attrs {
+        let Some(meta) = sval_attr(ctxt, attr)? else {
+            continue;
+        };
+
+        for (value_key, value) in meta {
+            if value_key.is_ident(request_key) {
+                return request.try_from_expr(&value);
+            }
         }
     }
 
@@ -494,15 +531,15 @@ pub(crate) fn get_unchecked<T: SvalAttribute>(
 }
 
 fn sval_attr<'a>(
-    _ctxt: &'a str,
+    ctxt: &'a str,
     attr: &'_ Attribute,
-) -> Option<impl IntoIterator<Item = (Path, Expr)> + 'a> {
+) -> syn::Result<Option<impl IntoIterator<Item = (Path, Expr)> + 'a>> {
     if !attr.path().is_ident("sval") {
-        return None;
+        return Ok(None);
     }
 
     let mut results = Vec::new();
-    let parse_result = attr.parse_nested_meta(|meta| {
+    attr.parse_nested_meta(|meta| {
         let expr: Expr = match meta.value() {
             Ok(value) => value.parse()?,
             // If there isn't a value associated with the item
@@ -515,12 +552,16 @@ fn sval_attr<'a>(
         results.push((path, expr));
 
         Ok(())
-    });
+    })
+    .map_err(|e| {
+        let mut r = syn::Error::new(
+            attr.span(),
+            format_args!("failed to parse attribute on {ctxt}"),
+        );
+        r.combine(e);
 
-    if let Err(_e) = parse_result {
-        // Silently ignore parse errors - they will be caught by check()
-        return None;
-    }
+        r
+    })?;
 
-    Some(results)
+    Ok(Some(results))
 }

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -15,7 +15,7 @@ pub(crate) struct TagAttr;
 impl SvalAttribute for TagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
+    fn from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
             Expr::Lit(lit) => Ok(self.from_lit(&lit.lit)?),
             Expr::Path(path) => Ok(path.path.clone()),
@@ -59,7 +59,7 @@ pub(crate) struct DataTagAttr;
 impl SvalAttribute for DataTagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
+    fn from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
             Expr::Lit(lit) => Ok(self.from_lit(&lit.lit)?),
             Expr::Path(path) => Ok(path.path.clone()),
@@ -103,7 +103,7 @@ pub(crate) struct LabelAttr;
 impl SvalAttribute for LabelAttr {
     type Result = LabelValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
+    fn from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
             Expr::Lit(lit) => Ok(self.from_lit(&lit.lit)?),
             Expr::Path(path) => Ok(LabelValue::Ident(quote!(#path))),
@@ -159,7 +159,7 @@ impl IndexAttr {
 impl SvalAttribute for IndexAttr {
     type Result = IndexValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
+    fn from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         match expr {
             // Take `-` into account
             Expr::Unary(ExprUnary {
@@ -431,7 +431,7 @@ pub(crate) trait RawAttribute {
 pub(crate) trait SvalAttribute: RawAttribute {
     type Result: 'static;
 
-    fn try_from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
+    fn from_expr(&self, expr: &Expr) -> syn::Result<Self::Result> {
         if let Expr::Lit(lit) = expr {
             Ok(self.from_lit(&lit.lit)?)
         } else {
@@ -550,7 +550,7 @@ pub(crate) fn get<T: SvalAttribute>(
 
         for (value_key, value) in meta {
             if value_key.is_ident(request_key) {
-                return Ok(Some(request.try_from_expr(&value)?));
+                return Ok(Some(request.from_expr(&value)?));
             }
         }
     }

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use syn::{Attribute, Expr, ExprUnary, Lit, Path, UnOp};
+use syn::{spanned::Spanned, Attribute, Error, Expr, ExprUnary, Lit, Path, Result, UnOp};
 
 use crate::{index::IndexValue, label::LabelValue};
 
@@ -17,17 +17,21 @@ impl SvalAttribute for TagAttr {
 
     fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
         match expr {
-            Expr::Lit(lit) => Some(self.from_lit(&lit.lit)),
+            Expr::Lit(lit) => Some(self.from_lit(&lit.lit).ok()?),
             Expr::Path(path) => Some(path.path.clone()),
             _ => None,
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Str(ref s) = lit {
-            s.parse().expect("invalid value")
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Str(s) => s
+                .parse()
+                .map_err(|_| Error::new(s.span(), "invalid tag: expected valid path")),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid tag: expected string literal",
+            )),
         }
     }
 }
@@ -51,17 +55,21 @@ impl SvalAttribute for DataTagAttr {
 
     fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
         match expr {
-            Expr::Lit(lit) => Some(self.from_lit(&lit.lit)),
+            Expr::Lit(lit) => Some(self.from_lit(&lit.lit).ok()?),
             Expr::Path(path) => Some(path.path.clone()),
             _ => None,
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Str(ref s) = lit {
-            s.parse().expect("invalid value")
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Str(s) => s
+                .parse()
+                .map_err(|_| Error::new(s.span(), "invalid data_tag: expected valid path")),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid data_tag: expected string literal",
+            )),
         }
     }
 }
@@ -85,17 +93,19 @@ impl SvalAttribute for LabelAttr {
 
     fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
         match expr {
-            Expr::Lit(lit) => Some(self.from_lit(&lit.lit)),
+            Expr::Lit(lit) => Some(self.from_lit(&lit.lit).ok()?),
             Expr::Path(path) => Some(LabelValue::Ident(quote!(#path))),
             _ => None,
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Str(ref s) = lit {
-            LabelValue::Const(s.value())
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Str(s) => Ok(LabelValue::Const(s.value())),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid label: expected string literal",
+            )),
         }
     }
 }
@@ -115,11 +125,12 @@ to use for the annotated item.
 pub(crate) struct IndexAttr;
 
 impl IndexAttr {
-    fn const_from_lit(&self, lit: &Lit) -> isize {
-        if let Lit::Int(ref n) = lit {
-            n.base10_parse().expect("invalid value")
-        } else {
-            panic!("unexpected value")
+    fn const_from_lit(&self, lit: &Lit) -> Result<isize> {
+        match lit {
+            Lit::Int(n) => n
+                .base10_parse()
+                .map_err(|_| Error::new(n.span(), "invalid index: expected integer")),
+            _ => Err(Error::new(lit.span(), "invalid index: expected integer")),
         }
     }
 }
@@ -136,19 +147,19 @@ impl SvalAttribute for IndexAttr {
                 ..
             }) => {
                 if let Expr::Lit(ref lit) = **expr {
-                    Some(IndexValue::Const(-(self.const_from_lit(&lit.lit))))
+                    Some(IndexValue::Const(-(self.const_from_lit(&lit.lit).ok()?)))
                 } else {
                     None
                 }
             }
-            Expr::Lit(lit) => Some(IndexValue::Const(self.const_from_lit(&lit.lit))),
+            Expr::Lit(lit) => Some(IndexValue::Const(self.const_from_lit(&lit.lit).ok()?)),
             Expr::Path(path) => Some(IndexValue::Ident(quote!(#path))),
             _ => None,
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        IndexValue::Const(self.const_from_lit(lit))
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        Ok(IndexValue::Const(self.const_from_lit(lit)?))
     }
 }
 
@@ -169,11 +180,10 @@ pub(crate) struct SkipAttr;
 impl SvalAttribute for SkipAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Bool(ref b) = lit {
-            b.value
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Bool(b) => Ok(b.value),
+            _ => Err(Error::new(lit.span(), "invalid skip: expected boolean")),
         }
     }
 }
@@ -194,11 +204,13 @@ pub(crate) struct UnlabeledFieldsAttr;
 impl SvalAttribute for UnlabeledFieldsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Bool(ref b) = lit {
-            b.value
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Bool(b) => Ok(b.value),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid unlabeled_fields: expected boolean",
+            )),
         }
     }
 }
@@ -219,11 +231,13 @@ pub(crate) struct UnindexedFieldsAttr;
 impl SvalAttribute for UnindexedFieldsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Bool(ref b) = lit {
-            b.value
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Bool(b) => Ok(b.value),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid unindexed_fields: expected boolean",
+            )),
         }
     }
 }
@@ -244,11 +258,13 @@ pub(crate) struct UnlabeledVariantsAttr;
 impl SvalAttribute for UnlabeledVariantsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Bool(ref b) = lit {
-            b.value
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Bool(b) => Ok(b.value),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid unlabeled_variants: expected boolean",
+            )),
         }
     }
 }
@@ -269,11 +285,13 @@ pub(crate) struct UnindexedVariantsAttr;
 impl SvalAttribute for UnindexedVariantsAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Bool(ref b) = lit {
-            b.value
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Bool(b) => Ok(b.value),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid unindexed_variants: expected boolean",
+            )),
         }
     }
 }
@@ -294,11 +312,10 @@ pub(crate) struct DynamicAttr;
 impl SvalAttribute for DynamicAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Bool(ref b) = lit {
-            b.value
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Bool(b) => Ok(b.value),
+            _ => Err(Error::new(lit.span(), "invalid dynamic: expected boolean")),
         }
     }
 }
@@ -320,11 +337,13 @@ pub(crate) struct TransparentAttr;
 impl SvalAttribute for TransparentAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
-        if let Lit::Bool(ref b) = lit {
-            b.value
-        } else {
-            panic!("unexpected value")
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
+        match lit {
+            Lit::Bool(b) => Ok(b.value),
+            _ => Err(Error::new(
+                lit.span(),
+                "invalid transparent: expected boolean",
+            )),
         }
     }
 }
@@ -345,18 +364,20 @@ pub(crate) struct FlattenAttr;
 impl SvalAttribute for FlattenAttr {
     type Result = bool;
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result {
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result> {
         #[cfg(not(feature = "flatten"))]
         {
             let _ = lit;
-            panic!("the `flatten` attribute can only be used when the `flatten` Cargo feature of `sval_derive` is enabled");
+            Err(Error::new(
+                proc_macro2::Span::call_site(),
+                "the `flatten` attribute can only be used when the `flatten` Cargo feature of `sval_derive` is enabled",
+            ))
         }
         #[cfg(feature = "flatten")]
         {
-            if let Lit::Bool(ref b) = lit {
-                b.value
-            } else {
-                panic!("unexpected value")
+            match lit {
+                Lit::Bool(b) => Ok(b.value),
+                _ => Err(Error::new(lit.span(), "invalid flatten: expected boolean")),
             }
         }
     }
@@ -377,35 +398,47 @@ pub(crate) trait SvalAttribute: RawAttribute {
 
     fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
         if let Expr::Lit(lit) = expr {
-            Some(self.from_lit(&lit.lit))
+            Some(self.from_lit(&lit.lit).ok()?)
         } else {
             None
         }
     }
 
-    fn from_lit(&self, lit: &Lit) -> Self::Result;
+    fn from_lit(&self, lit: &Lit) -> Result<Self::Result>;
 }
 
-pub(crate) fn ensure_empty(ctxt: &str, attrs: &[Attribute]) {
+pub(crate) fn ensure_empty(ctxt: &str, attrs: &[Attribute]) -> Result<()> {
     // Just ensure the attribute list is empty
     for (value_key, _) in attrs
         .iter()
         .filter_map(|attr| sval_attr(ctxt, attr))
         .flatten()
     {
-        panic!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt);
+        return Err(Error::new(
+            value_key.span(),
+            format_args!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt),
+        ));
     }
+    Ok(())
 }
 
-pub(crate) fn ensure_missing<T: SvalAttribute>(ctxt: &str, request: T, attrs: &[Attribute]) {
+pub(crate) fn ensure_missing<T: SvalAttribute>(
+    ctxt: &str,
+    request: T,
+    attrs: &[Attribute],
+) -> Result<()> {
     let key = request.key().to_owned();
 
     if get_unchecked::<T>(ctxt, request, attrs).is_some() {
-        panic!("unsupported attribute `{}` on {}", key, ctxt);
+        return Err(Error::new(
+            proc_macro2::Span::call_site(),
+            format_args!("unsupported attribute `{}` on {}", key, ctxt),
+        ));
     }
+    Ok(())
 }
 
-pub(crate) fn check(ctxt: &str, allowed: &[&dyn RawAttribute], attrs: &[Attribute]) {
+pub(crate) fn check(ctxt: &str, allowed: &[&dyn RawAttribute], attrs: &[Attribute]) -> Result<()> {
     let mut seen = HashSet::new();
 
     for (value_key, _) in attrs
@@ -422,15 +455,22 @@ pub(crate) fn check(ctxt: &str, allowed: &[&dyn RawAttribute], attrs: &[Attribut
                 is_valid_attr = true;
 
                 if !seen.insert(attr_key) {
-                    panic!("duplicate attribute `{}` on {}", quote!(#value_key), ctxt);
+                    return Err(Error::new(
+                        value_key.span(),
+                        format_args!("duplicate attribute `{}` on {}", quote!(#value_key), ctxt),
+                    ));
                 }
             }
         }
 
         if !is_valid_attr {
-            panic!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt);
+            return Err(Error::new(
+                value_key.span(),
+                format_args!("unsupported attribute `{}` on {}", quote!(#value_key), ctxt),
+            ));
         }
     }
+    Ok(())
 }
 
 pub(crate) fn get_unchecked<T: SvalAttribute>(
@@ -446,7 +486,7 @@ pub(crate) fn get_unchecked<T: SvalAttribute>(
         .flatten()
     {
         if value_key.is_ident(request_key) {
-            return Some(request.try_from_expr(&value).expect("unexpected value"));
+            return request.try_from_expr(&value);
         }
     }
 
@@ -454,7 +494,7 @@ pub(crate) fn get_unchecked<T: SvalAttribute>(
 }
 
 fn sval_attr<'a>(
-    ctxt: &'a str,
+    _ctxt: &'a str,
     attr: &'_ Attribute,
 ) -> Option<impl IntoIterator<Item = (Path, Expr)> + 'a> {
     if !attr.path().is_ident("sval") {
@@ -462,7 +502,7 @@ fn sval_attr<'a>(
     }
 
     let mut results = Vec::new();
-    attr.parse_nested_meta(|meta| {
+    let parse_result = attr.parse_nested_meta(|meta| {
         let expr: Expr = match meta.value() {
             Ok(value) => value.parse()?,
             // If there isn't a value associated with the item
@@ -475,8 +515,12 @@ fn sval_attr<'a>(
         results.push((path, expr));
 
         Ok(())
-    })
-    .unwrap_or_else(|e| panic!("failed to parse attribute on {}: {}", ctxt, e));
+    });
+
+    if let Err(_e) = parse_result {
+        // Silently ignore parse errors - they will be caught by check()
+        return None;
+    }
 
     Some(results)
 }

--- a/derive_macros/src/attr.rs
+++ b/derive_macros/src/attr.rs
@@ -15,11 +15,11 @@ pub(crate) struct TagAttr;
 impl SvalAttribute for TagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
+    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
         match expr {
-            Expr::Lit(lit) => Some(self.from_lit(&lit.lit).ok()?),
-            Expr::Path(path) => Some(path.path.clone()),
-            _ => None,
+            Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
+            Expr::Path(path) => Ok(Some(path.path.clone())),
+            _ => Ok(None),
         }
     }
 
@@ -53,11 +53,11 @@ pub(crate) struct DataTagAttr;
 impl SvalAttribute for DataTagAttr {
     type Result = syn::Path;
 
-    fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
+    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
         match expr {
-            Expr::Lit(lit) => Some(self.from_lit(&lit.lit).ok()?),
-            Expr::Path(path) => Some(path.path.clone()),
-            _ => None,
+            Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
+            Expr::Path(path) => Ok(Some(path.path.clone())),
+            _ => Ok(None),
         }
     }
 
@@ -91,11 +91,11 @@ pub(crate) struct LabelAttr;
 impl SvalAttribute for LabelAttr {
     type Result = LabelValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
+    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
         match expr {
-            Expr::Lit(lit) => Some(self.from_lit(&lit.lit).ok()?),
-            Expr::Path(path) => Some(LabelValue::Ident(quote!(#path))),
-            _ => None,
+            Expr::Lit(lit) => Ok(Some(self.from_lit(&lit.lit)?)),
+            Expr::Path(path) => Ok(Some(LabelValue::Ident(quote!(#path)))),
+            _ => Ok(None),
         }
     }
 
@@ -138,7 +138,7 @@ impl IndexAttr {
 impl SvalAttribute for IndexAttr {
     type Result = IndexValue;
 
-    fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
+    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
         match expr {
             // Take `-` into account
             Expr::Unary(ExprUnary {
@@ -147,14 +147,14 @@ impl SvalAttribute for IndexAttr {
                 ..
             }) => {
                 if let Expr::Lit(ref lit) = **expr {
-                    Some(IndexValue::Const(-(self.const_from_lit(&lit.lit).ok()?)))
+                    Ok(Some(IndexValue::Const(-(self.const_from_lit(&lit.lit)?))))
                 } else {
-                    None
+                    Ok(None)
                 }
             }
-            Expr::Lit(lit) => Some(IndexValue::Const(self.const_from_lit(&lit.lit).ok()?)),
-            Expr::Path(path) => Some(IndexValue::Ident(quote!(#path))),
-            _ => None,
+            Expr::Lit(lit) => Ok(Some(IndexValue::Const(self.const_from_lit(&lit.lit)?))),
+            Expr::Path(path) => Ok(Some(IndexValue::Ident(quote!(#path)))),
+            _ => Ok(None),
         }
     }
 
@@ -396,11 +396,11 @@ pub(crate) trait RawAttribute {
 pub(crate) trait SvalAttribute: RawAttribute {
     type Result: 'static;
 
-    fn try_from_expr(&self, expr: &Expr) -> Option<Self::Result> {
+    fn try_from_expr(&self, expr: &Expr) -> Result<Option<Self::Result>> {
         if let Expr::Lit(lit) = expr {
-            Some(self.from_lit(&lit.lit).ok()?)
+            Ok(Some(self.from_lit(&lit.lit)?))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -429,7 +429,7 @@ pub(crate) fn ensure_missing<T: SvalAttribute>(
 ) -> Result<()> {
     let key = request.key().to_owned();
 
-    if get_unchecked::<T>(ctxt, request, attrs).is_some() {
+    if get_unchecked::<T>(ctxt, request, attrs)?.is_some() {
         return Err(Error::new(
             proc_macro2::Span::call_site(),
             format_args!("unsupported attribute `{}` on {}", key, ctxt),
@@ -477,7 +477,7 @@ pub(crate) fn get_unchecked<T: SvalAttribute>(
     ctxt: &str,
     request: T,
     attrs: &[Attribute],
-) -> Option<T::Result> {
+) -> Result<Option<T::Result>> {
     let request_key = request.key();
 
     for (value_key, value) in attrs
@@ -490,7 +490,7 @@ pub(crate) fn get_unchecked<T: SvalAttribute>(
         }
     }
 
-    None
+    Ok(None)
 }
 
 fn sval_attr<'a>(

--- a/derive_macros/src/derive.rs
+++ b/derive_macros/src/derive.rs
@@ -4,14 +4,14 @@ mod derive_struct;
 mod derive_unit_struct;
 mod derive_void;
 
-use syn::{spanned::Spanned, Data, DataEnum, DataStruct, DeriveInput, Error, Fields};
+use syn::{spanned::Spanned, Data, DataEnum, DataStruct, DeriveInput, Fields};
 
 use self::{
     derive_enum::*, derive_newtype::*, derive_struct::*, derive_unit_struct::*, derive_void::*,
 };
 
 pub(crate) fn derive(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
-    let tokens = match &input.data {
+    Ok(match &input.data {
         Data::Struct(DataStruct {
             fields: Fields::Unit,
             ..
@@ -44,13 +44,12 @@ pub(crate) fn derive(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream
             derive_enum(&input.ident, &input.generics, variants.iter(), &attrs)?
         }
         Data::Union(u) => {
-            return Err(Error::new(
+            return Err(syn::Error::new(
                 u.union_token.span(),
                 "unions are not supported for sval derive",
             ));
         }
-    };
-    Ok(tokens)
+    })
 }
 
 fn impl_tokens(

--- a/derive_macros/src/derive.rs
+++ b/derive_macros/src/derive.rs
@@ -4,47 +4,53 @@ mod derive_struct;
 mod derive_unit_struct;
 mod derive_void;
 
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields};
+use syn::{spanned::Spanned, Data, DataEnum, DataStruct, DeriveInput, Error, Fields};
 
 use self::{
     derive_enum::*, derive_newtype::*, derive_struct::*, derive_unit_struct::*, derive_void::*,
 };
 
-pub(crate) fn derive(input: DeriveInput) -> proc_macro2::TokenStream {
-    match &input.data {
+pub(crate) fn derive(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let tokens = match &input.data {
         Data::Struct(DataStruct {
             fields: Fields::Unit,
             ..
         }) => {
-            let attrs = UnitStructAttrs::from_attrs(&input.attrs);
+            let attrs = UnitStructAttrs::from_attrs(&input.attrs)?;
 
-            derive_unit_struct(&input.ident, &input.generics, &attrs)
+            derive_unit_struct(&input.ident, &input.generics, &attrs)?
         }
         Data::Struct(DataStruct {
             fields: Fields::Unnamed(ref fields),
             ..
         }) if fields.unnamed.len() == 1 => {
-            let attrs = NewtypeAttrs::from_attrs(&input.attrs);
+            let attrs = NewtypeAttrs::from_attrs(&input.attrs)?;
 
-            derive_newtype(&input.ident, &input.generics, &fields.unnamed[0], &attrs)
+            derive_newtype(&input.ident, &input.generics, &fields.unnamed[0], &attrs)?
         }
         Data::Struct(DataStruct { ref fields, .. }) => {
-            let attrs = StructAttrs::from_attrs(&input.attrs);
+            let attrs = StructAttrs::from_attrs(&input.attrs)?;
 
-            derive_struct(&input.ident, &input.generics, fields, &attrs)
+            derive_struct(&input.ident, &input.generics, fields, &attrs)?
         }
         Data::Enum(DataEnum { ref variants, .. }) if variants.len() == 0 => {
-            let attrs = VoidAttrs::from_attrs(&input.attrs);
+            let attrs = VoidAttrs::from_attrs(&input.attrs)?;
 
-            derive_void(&input.ident, &input.generics, &attrs)
+            derive_void(&input.ident, &input.generics, &attrs)?
         }
         Data::Enum(DataEnum { variants, .. }) => {
-            let attrs = EnumAttrs::from_attrs(&input.attrs);
+            let attrs = EnumAttrs::from_attrs(&input.attrs)?;
 
-            derive_enum(&input.ident, &input.generics, variants.iter(), &attrs)
+            derive_enum(&input.ident, &input.generics, variants.iter(), &attrs)?
         }
-        _ => panic!("unsupported container type"),
-    }
+        Data::Union(u) => {
+            return Err(Error::new(
+                u.union_token.span(),
+                "unions are not supported for sval derive",
+            ));
+        }
+    };
+    Ok(tokens)
 }
 
 fn impl_tokens(

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -163,7 +163,7 @@ pub(crate) fn derive_enum<'a>(
         )?;
 
         let discriminant = if let Some((_, discriminant)) = &variant.discriminant {
-            Some(attr::IndexAttr.try_from_expr(discriminant)?)
+            Some(attr::IndexAttr.from_expr(discriminant)?)
         } else {
             None
         };

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -37,14 +37,14 @@ impl EnumAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("enum", attr::TagAttr, attrs);
-        let label = attr::get_unchecked("enum", attr::LabelAttr, attrs);
-        let index = attr::get_unchecked("enum", attr::IndexAttr, attrs);
+        let tag = attr::get_unchecked("enum", attr::TagAttr, attrs)?;
+        let label = attr::get_unchecked("enum", attr::LabelAttr, attrs)?;
+        let index = attr::get_unchecked("enum", attr::IndexAttr, attrs)?;
         let unlabeled_variants =
-            attr::get_unchecked("enum", attr::UnlabeledVariantsAttr, attrs).unwrap_or(false);
+            attr::get_unchecked("enum", attr::UnlabeledVariantsAttr, attrs)?.unwrap_or(false);
         let unindexed_variants =
-            attr::get_unchecked("enum", attr::UnindexedVariantsAttr, attrs).unwrap_or(false);
-        let dynamic = attr::get_unchecked("enum", attr::DynamicAttr, attrs).unwrap_or(false);
+            attr::get_unchecked("enum", attr::UnindexedVariantsAttr, attrs)?.unwrap_or(false);
+        let dynamic = attr::get_unchecked("enum", attr::DynamicAttr, attrs)?.unwrap_or(false);
 
         if dynamic {
             if tag.is_some() {
@@ -162,10 +162,11 @@ pub(crate) fn derive_enum<'a>(
             &variant.attrs,
         )?;
 
-        let discriminant = variant
-            .discriminant
-            .as_ref()
-            .and_then(|(_, discriminant)| attr::IndexAttr.try_from_expr(discriminant));
+        let discriminant = if let Some((_, discriminant)) = &variant.discriminant {
+            attr::IndexAttr.try_from_expr(discriminant)?
+        } else {
+            None
+        };
 
         let variant_ident = &variant.ident;
 

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -37,14 +37,14 @@ impl EnumAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("enum", attr::TagAttr, attrs)?;
-        let label = attr::get_unchecked("enum", attr::LabelAttr, attrs)?;
-        let index = attr::get_unchecked("enum", attr::IndexAttr, attrs)?;
+        let tag = attr::get("enum", attr::TagAttr, attrs)?;
+        let label = attr::get("enum", attr::LabelAttr, attrs)?;
+        let index = attr::get("enum", attr::IndexAttr, attrs)?;
         let unlabeled_variants =
-            attr::get_unchecked("enum", attr::UnlabeledVariantsAttr, attrs)?.unwrap_or(false);
+            attr::get("enum", attr::UnlabeledVariantsAttr, attrs)?.unwrap_or(false);
         let unindexed_variants =
-            attr::get_unchecked("enum", attr::UnindexedVariantsAttr, attrs)?.unwrap_or(false);
-        let dynamic = attr::get_unchecked("enum", attr::DynamicAttr, attrs)?.unwrap_or(false);
+            attr::get("enum", attr::UnindexedVariantsAttr, attrs)?.unwrap_or(false);
+        let dynamic = attr::get("enum", attr::DynamicAttr, attrs)?.unwrap_or(false);
 
         if dynamic {
             if tag.is_some() {
@@ -163,7 +163,7 @@ pub(crate) fn derive_enum<'a>(
         )?;
 
         let discriminant = if let Some((_, discriminant)) = &variant.discriminant {
-            attr::IndexAttr.try_from_expr(discriminant)?
+            Some(attr::IndexAttr.try_from_expr(discriminant)?)
         } else {
             None
         };

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -1,4 +1,4 @@
-use syn::{Attribute, Error, Fields, Generics, Ident, Path, Variant};
+use syn::{Attribute, Fields, Generics, Ident, Path, Variant};
 
 use crate::{
     attr::{self, SvalAttribute},
@@ -48,32 +48,32 @@ impl EnumAttrs {
 
         if dynamic {
             if tag.is_some() {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "dynamic enums can't have tags",
                 ));
             }
             if label.is_some() {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "dynamic enums can't have labels",
                 ));
             }
             if index.is_some() {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "dynamic enums can't have indexes",
                 ));
             }
 
             if unlabeled_variants {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "dynamic enums don't have variants",
                 ));
             }
             if unindexed_variants {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "dynamic enums don't have variants",
                 ));

--- a/derive_macros/src/derive/derive_enum.rs
+++ b/derive_macros/src/derive/derive_enum.rs
@@ -1,4 +1,4 @@
-use syn::{Attribute, Fields, Generics, Ident, Path, Variant};
+use syn::{Attribute, Error, Fields, Generics, Ident, Path, Variant};
 
 use crate::{
     attr::{self, SvalAttribute},
@@ -23,7 +23,7 @@ pub(crate) struct EnumAttrs {
 }
 
 impl EnumAttrs {
-    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Self {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
         attr::check(
             "enum",
             &[
@@ -35,7 +35,7 @@ impl EnumAttrs {
                 &attr::UnindexedVariantsAttr,
             ],
             attrs,
-        );
+        )?;
 
         let tag = attr::get_unchecked("enum", attr::TagAttr, attrs);
         let label = attr::get_unchecked("enum", attr::LabelAttr, attrs);
@@ -47,22 +47,47 @@ impl EnumAttrs {
         let dynamic = attr::get_unchecked("enum", attr::DynamicAttr, attrs).unwrap_or(false);
 
         if dynamic {
-            assert!(tag.is_none(), "dynamic enums can't have tags");
-            assert!(label.is_none(), "dynamic enums can't have labels");
-            assert!(index.is_none(), "dynamic enums can't have indexes");
+            if tag.is_some() {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "dynamic enums can't have tags",
+                ));
+            }
+            if label.is_some() {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "dynamic enums can't have labels",
+                ));
+            }
+            if index.is_some() {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "dynamic enums can't have indexes",
+                ));
+            }
 
-            assert!(!unlabeled_variants, "dynamic enums don't have variants");
-            assert!(!unindexed_variants, "dynamic enums don't have variants");
+            if unlabeled_variants {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "dynamic enums don't have variants",
+                ));
+            }
+            if unindexed_variants {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "dynamic enums don't have variants",
+                ));
+            }
         }
 
-        EnumAttrs {
+        Ok(EnumAttrs {
             tag,
             label,
             index,
             unlabeled_variants,
             unindexed_variants,
             dynamic,
-        }
+        })
     }
 
     pub(crate) fn tag(&self) -> Option<&Path> {
@@ -83,7 +108,7 @@ pub(crate) fn derive_enum<'a>(
     generics: &Generics,
     variants: impl Iterator<Item = &'a Variant> + 'a,
     attrs: &EnumAttrs,
-) -> proc_macro2::TokenStream {
+) -> syn::Result<proc_macro2::TokenStream> {
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
 
     let bound = parse_quote!(sval::Value);
@@ -135,7 +160,7 @@ pub(crate) fn derive_enum<'a>(
                 &attr::UnindexedFieldsAttr,
             ],
             &variant.attrs,
-        );
+        )?;
 
         let discriminant = variant
             .discriminant
@@ -146,7 +171,7 @@ pub(crate) fn derive_enum<'a>(
 
         variant_match_arms.push(match variant.fields {
             Fields::Unnamed(ref fields) if fields.unnamed.len() == 1 => {
-                let attrs = NewtypeAttrs::from_attrs(&variant.attrs);
+                let attrs = NewtypeAttrs::from_attrs(&variant.attrs)?;
 
                 stream_newtype(
                     quote!(#ident :: #variant_ident),
@@ -155,20 +180,20 @@ pub(crate) fn derive_enum<'a>(
                     variant_label(attrs.label(), variant_ident),
                     variant_index(attrs.index(), discriminant),
                     variant_transparent,
-                )
+                )?
             }
             Fields::Unit => {
-                let attrs = UnitStructAttrs::from_attrs(&variant.attrs);
+                let attrs = UnitStructAttrs::from_attrs(&variant.attrs)?;
 
                 stream_tag(
                     quote!(#ident :: #variant_ident),
                     attrs.tag(),
                     unit_variant_label(attrs.label(), variant_ident),
                     variant_index(attrs.index(), discriminant),
-                )
+                )?
             }
             Fields::Named(ref fields) => {
-                let attrs = StructAttrs::from_attrs(&variant.attrs);
+                let attrs = StructAttrs::from_attrs(&variant.attrs)?;
 
                 stream_record_tuple(
                     quote!(#ident :: #variant_ident),
@@ -179,10 +204,10 @@ pub(crate) fn derive_enum<'a>(
                     variant_index(attrs.index(), discriminant),
                     attrs.unlabeled_fields(),
                     attrs.unindexed_fields(),
-                )
+                )?
             }
             Fields::Unnamed(ref fields) => {
-                let attrs = StructAttrs::from_attrs(&variant.attrs);
+                let attrs = StructAttrs::from_attrs(&variant.attrs)?;
 
                 stream_record_tuple(
                     quote!(#ident :: #variant_ident),
@@ -193,12 +218,12 @@ pub(crate) fn derive_enum<'a>(
                     variant_index(attrs.index(), discriminant),
                     attrs.unlabeled_fields(),
                     attrs.unindexed_fields(),
-                )
+                )?
             }
         });
     }
 
-    if attrs.dynamic {
+    Ok(if attrs.dynamic {
         impl_tokens(
             impl_generics,
             ident,
@@ -235,5 +260,5 @@ pub(crate) fn derive_enum<'a>(
             }),
             Some(tag_owned),
         )
-    }
+    })
 }

--- a/derive_macros/src/derive/derive_newtype.rs
+++ b/derive_macros/src/derive/derive_newtype.rs
@@ -1,4 +1,4 @@
-use syn::{Attribute, Field, Generics, Ident, Path};
+use syn::{Attribute, Error, Field, Generics, Ident, Path};
 
 use crate::{
     attr, bound,
@@ -17,7 +17,7 @@ pub(crate) struct NewtypeAttrs {
 }
 
 impl NewtypeAttrs {
-    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Self {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
         attr::check(
             "newtype",
             &[
@@ -27,7 +27,7 @@ impl NewtypeAttrs {
                 &attr::TransparentAttr,
             ],
             attrs,
-        );
+        )?;
 
         let tag = attr::get_unchecked("newtype", attr::TagAttr, attrs);
         let label = attr::get_unchecked("newtype", attr::LabelAttr, attrs);
@@ -36,17 +36,32 @@ impl NewtypeAttrs {
             attr::get_unchecked("newtype", attr::TransparentAttr, attrs).unwrap_or(false);
 
         if transparent {
-            assert!(tag.is_none(), "transparent values cannot have tags");
-            assert!(label.is_none(), "transparent values cannot have labels");
-            assert!(index.is_none(), "transparent values cannot have indexes");
+            if tag.is_some() {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "transparent values cannot have tags",
+                ));
+            }
+            if label.is_some() {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "transparent values cannot have labels",
+                ));
+            }
+            if index.is_some() {
+                return Err(Error::new(
+                    proc_macro2::Span::call_site(),
+                    "transparent values cannot have indexes",
+                ));
+            }
         }
 
-        NewtypeAttrs {
+        Ok(NewtypeAttrs {
             tag,
             label,
             index,
             transparent,
-        }
+        })
     }
 
     pub(crate) fn tag(&self) -> Option<&Path> {
@@ -71,7 +86,7 @@ pub(crate) fn derive_newtype<'a>(
     generics: &Generics,
     field: &Field,
     attrs: &NewtypeAttrs,
-) -> proc_macro2::TokenStream {
+) -> syn::Result<proc_macro2::TokenStream> {
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
 
     let bound = parse_quote!(sval::Value);
@@ -84,11 +99,11 @@ pub(crate) fn derive_newtype<'a>(
         Some(label_or_ident(attrs.label(), ident)),
         attrs.index(),
         attrs.transparent(),
-    );
+    )?;
 
     let tag = quote_optional_tag_owned(attrs.tag());
 
-    impl_tokens(
+    Ok(impl_tokens(
         impl_generics,
         ident,
         ty_generics,
@@ -101,5 +116,5 @@ pub(crate) fn derive_newtype<'a>(
             sval::__private::result::Result::Ok(())
         }),
         Some(tag),
-    )
+    ))
 }

--- a/derive_macros/src/derive/derive_newtype.rs
+++ b/derive_macros/src/derive/derive_newtype.rs
@@ -1,4 +1,4 @@
-use syn::{Attribute, Error, Field, Generics, Ident, Path};
+use syn::{Attribute, Field, Generics, Ident, Path};
 
 use crate::{
     attr, bound,
@@ -37,19 +37,19 @@ impl NewtypeAttrs {
 
         if transparent {
             if tag.is_some() {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "transparent values cannot have tags",
                 ));
             }
             if label.is_some() {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "transparent values cannot have labels",
                 ));
             }
             if index.is_some() {
-                return Err(Error::new(
+                return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     "transparent values cannot have indexes",
                 ));

--- a/derive_macros/src/derive/derive_newtype.rs
+++ b/derive_macros/src/derive/derive_newtype.rs
@@ -29,11 +29,11 @@ impl NewtypeAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("newtype", attr::TagAttr, attrs);
-        let label = attr::get_unchecked("newtype", attr::LabelAttr, attrs);
-        let index = attr::get_unchecked("newtype", attr::IndexAttr, attrs);
+        let tag = attr::get_unchecked("newtype", attr::TagAttr, attrs)?;
+        let label = attr::get_unchecked("newtype", attr::LabelAttr, attrs)?;
+        let index = attr::get_unchecked("newtype", attr::IndexAttr, attrs)?;
         let transparent =
-            attr::get_unchecked("newtype", attr::TransparentAttr, attrs).unwrap_or(false);
+            attr::get_unchecked("newtype", attr::TransparentAttr, attrs)?.unwrap_or(false);
 
         if transparent {
             if tag.is_some() {

--- a/derive_macros/src/derive/derive_newtype.rs
+++ b/derive_macros/src/derive/derive_newtype.rs
@@ -29,11 +29,10 @@ impl NewtypeAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("newtype", attr::TagAttr, attrs)?;
-        let label = attr::get_unchecked("newtype", attr::LabelAttr, attrs)?;
-        let index = attr::get_unchecked("newtype", attr::IndexAttr, attrs)?;
-        let transparent =
-            attr::get_unchecked("newtype", attr::TransparentAttr, attrs)?.unwrap_or(false);
+        let tag = attr::get("newtype", attr::TagAttr, attrs)?;
+        let label = attr::get("newtype", attr::LabelAttr, attrs)?;
+        let index = attr::get("newtype", attr::IndexAttr, attrs)?;
+        let transparent = attr::get("newtype", attr::TransparentAttr, attrs)?.unwrap_or(false);
 
         if transparent {
             if tag.is_some() {

--- a/derive_macros/src/derive/derive_struct.rs
+++ b/derive_macros/src/derive/derive_struct.rs
@@ -31,14 +31,14 @@ impl StructAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("struct", attr::TagAttr, attrs);
-        let label = attr::get_unchecked("struct", attr::LabelAttr, attrs);
-        let index = attr::get_unchecked("struct", attr::IndexAttr, attrs);
+        let tag = attr::get_unchecked("struct", attr::TagAttr, attrs)?;
+        let label = attr::get_unchecked("struct", attr::LabelAttr, attrs)?;
+        let index = attr::get_unchecked("struct", attr::IndexAttr, attrs)?;
 
         let unlabeled_fields =
-            attr::get_unchecked("struct", attr::UnlabeledFieldsAttr, attrs).unwrap_or(false);
+            attr::get_unchecked("struct", attr::UnlabeledFieldsAttr, attrs)?.unwrap_or(false);
         let unindexed_fields =
-            attr::get_unchecked("struct", attr::UnindexedFieldsAttr, attrs).unwrap_or(false);
+            attr::get_unchecked("struct", attr::UnindexedFieldsAttr, attrs)?.unwrap_or(false);
 
         Ok(StructAttrs {
             tag,

--- a/derive_macros/src/derive/derive_struct.rs
+++ b/derive_macros/src/derive/derive_struct.rs
@@ -18,7 +18,7 @@ pub(crate) struct StructAttrs {
 }
 
 impl StructAttrs {
-    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Self {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
         attr::check(
             "struct",
             &[
@@ -29,7 +29,7 @@ impl StructAttrs {
                 &attr::UnindexedFieldsAttr,
             ],
             attrs,
-        );
+        )?;
 
         let tag = attr::get_unchecked("struct", attr::TagAttr, attrs);
         let label = attr::get_unchecked("struct", attr::LabelAttr, attrs);
@@ -40,13 +40,13 @@ impl StructAttrs {
         let unindexed_fields =
             attr::get_unchecked("struct", attr::UnindexedFieldsAttr, attrs).unwrap_or(false);
 
-        StructAttrs {
+        Ok(StructAttrs {
             tag,
             label,
             index,
             unlabeled_fields,
             unindexed_fields,
-        }
+        })
     }
 
     pub(crate) fn tag(&self) -> Option<&Path> {
@@ -75,7 +75,7 @@ pub(crate) fn derive_struct<'a>(
     generics: &Generics,
     fields: &Fields,
     attrs: &StructAttrs,
-) -> proc_macro2::TokenStream {
+) -> syn::Result<proc_macro2::TokenStream> {
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
 
     let bound = parse_quote!(sval::Value);
@@ -84,7 +84,10 @@ pub(crate) fn derive_struct<'a>(
     let (fields, target) = match fields {
         Fields::Named(ref fields) => (&fields.named, RecordTupleTarget::named_fields()),
         Fields::Unnamed(ref fields) => (&fields.unnamed, RecordTupleTarget::unnamed_fields()),
-        _ => unreachable!(),
+        Fields::Unit => {
+            // Unreachable: unit structs are handled separately in derive()
+            unreachable!()
+        }
     };
 
     let match_arm = stream_record_tuple(
@@ -96,11 +99,11 @@ pub(crate) fn derive_struct<'a>(
         attrs.index(),
         attrs.unlabeled_fields(),
         attrs.unindexed_fields(),
-    );
+    )?;
 
     let tag = quote_optional_tag_owned(attrs.tag());
 
-    impl_tokens(
+    Ok(impl_tokens(
         impl_generics,
         ident,
         ty_generics,
@@ -113,5 +116,5 @@ pub(crate) fn derive_struct<'a>(
             sval::__private::result::Result::Ok(())
         }),
         Some(tag),
-    )
+    ))
 }

--- a/derive_macros/src/derive/derive_struct.rs
+++ b/derive_macros/src/derive/derive_struct.rs
@@ -31,14 +31,14 @@ impl StructAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("struct", attr::TagAttr, attrs)?;
-        let label = attr::get_unchecked("struct", attr::LabelAttr, attrs)?;
-        let index = attr::get_unchecked("struct", attr::IndexAttr, attrs)?;
+        let tag = attr::get("struct", attr::TagAttr, attrs)?;
+        let label = attr::get("struct", attr::LabelAttr, attrs)?;
+        let index = attr::get("struct", attr::IndexAttr, attrs)?;
 
         let unlabeled_fields =
-            attr::get_unchecked("struct", attr::UnlabeledFieldsAttr, attrs)?.unwrap_or(false);
+            attr::get("struct", attr::UnlabeledFieldsAttr, attrs)?.unwrap_or(false);
         let unindexed_fields =
-            attr::get_unchecked("struct", attr::UnindexedFieldsAttr, attrs)?.unwrap_or(false);
+            attr::get("struct", attr::UnindexedFieldsAttr, attrs)?.unwrap_or(false);
 
         Ok(StructAttrs {
             tag,

--- a/derive_macros/src/derive/derive_unit_struct.rs
+++ b/derive_macros/src/derive/derive_unit_struct.rs
@@ -23,9 +23,9 @@ impl UnitStructAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("unit struct", attr::TagAttr, attrs)?;
-        let label = attr::get_unchecked("unit struct", attr::LabelAttr, attrs)?;
-        let index = attr::get_unchecked("unit struct", attr::IndexAttr, attrs)?;
+        let tag = attr::get("unit struct", attr::TagAttr, attrs)?;
+        let label = attr::get("unit struct", attr::LabelAttr, attrs)?;
+        let index = attr::get("unit struct", attr::IndexAttr, attrs)?;
 
         Ok(UnitStructAttrs { tag, label, index })
     }

--- a/derive_macros/src/derive/derive_unit_struct.rs
+++ b/derive_macros/src/derive/derive_unit_struct.rs
@@ -23,9 +23,9 @@ impl UnitStructAttrs {
             attrs,
         )?;
 
-        let tag = attr::get_unchecked("unit struct", attr::TagAttr, attrs);
-        let label = attr::get_unchecked("unit struct", attr::LabelAttr, attrs);
-        let index = attr::get_unchecked("unit struct", attr::IndexAttr, attrs);
+        let tag = attr::get_unchecked("unit struct", attr::TagAttr, attrs)?;
+        let label = attr::get_unchecked("unit struct", attr::LabelAttr, attrs)?;
+        let index = attr::get_unchecked("unit struct", attr::IndexAttr, attrs)?;
 
         Ok(UnitStructAttrs { tag, label, index })
     }

--- a/derive_macros/src/derive/derive_unit_struct.rs
+++ b/derive_macros/src/derive/derive_unit_struct.rs
@@ -16,18 +16,18 @@ pub(crate) struct UnitStructAttrs {
 }
 
 impl UnitStructAttrs {
-    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Self {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
         attr::check(
             "unit struct",
             &[&attr::TagAttr, &attr::LabelAttr, &attr::IndexAttr],
             attrs,
-        );
+        )?;
 
         let tag = attr::get_unchecked("unit struct", attr::TagAttr, attrs);
         let label = attr::get_unchecked("unit struct", attr::LabelAttr, attrs);
         let index = attr::get_unchecked("unit struct", attr::IndexAttr, attrs);
 
-        UnitStructAttrs { tag, label, index }
+        Ok(UnitStructAttrs { tag, label, index })
     }
 
     pub(crate) fn tag(&self) -> Option<&Path> {
@@ -47,7 +47,7 @@ pub(crate) fn derive_unit_struct<'a>(
     ident: &Ident,
     generics: &Generics,
     attrs: &UnitStructAttrs,
-) -> proc_macro2::TokenStream {
+) -> syn::Result<proc_macro2::TokenStream> {
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
 
     let bound = parse_quote!(sval::Value);
@@ -58,11 +58,11 @@ pub(crate) fn derive_unit_struct<'a>(
         attrs.tag(),
         Some(label_or_ident(attrs.label(), ident)),
         attrs.index(),
-    );
+    )?;
 
     let tag = quote_optional_tag_owned(attrs.tag());
 
-    impl_tokens(
+    Ok(impl_tokens(
         impl_generics,
         ident,
         ty_generics,
@@ -75,5 +75,5 @@ pub(crate) fn derive_unit_struct<'a>(
             sval::__private::result::Result::Ok(())
         }),
         Some(tag),
-    )
+    ))
 }

--- a/derive_macros/src/derive/derive_void.rs
+++ b/derive_macros/src/derive/derive_void.rs
@@ -5,10 +5,10 @@ use crate::{attr, bound, derive::impl_tokens};
 pub(crate) struct VoidAttrs {}
 
 impl VoidAttrs {
-    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Self {
-        attr::ensure_empty("void enum", attrs);
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+        attr::ensure_empty("void enum", attrs)?;
 
-        VoidAttrs {}
+        Ok(VoidAttrs {})
     }
 }
 
@@ -16,7 +16,7 @@ pub(crate) fn derive_void<'a>(
     ident: &Ident,
     generics: &Generics,
     attrs: &VoidAttrs,
-) -> proc_macro2::TokenStream {
+) -> syn::Result<proc_macro2::TokenStream> {
     let _ = attrs;
 
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
@@ -24,12 +24,12 @@ pub(crate) fn derive_void<'a>(
     let bound = parse_quote!(sval::Value);
     let bounded_where_clause = bound::where_clause_with_bound(&generics, bound);
 
-    impl_tokens(
+    Ok(impl_tokens(
         impl_generics,
         ident,
         ty_generics,
         &bounded_where_clause,
         quote!({ match *self {} }),
         None,
-    )
+    ))
 }

--- a/derive_macros/src/lib.rs
+++ b/derive_macros/src/lib.rs
@@ -18,5 +18,10 @@ use syn::DeriveInput;
 
 #[proc_macro_derive(Value, attributes(sval))]
 pub fn derive_value(input: TokenStream) -> TokenStream {
-    TokenStream::from(derive::derive(parse_macro_input!(input as DeriveInput)))
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match derive::derive(input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
 }

--- a/derive_macros/src/stream/stream_newtype.rs
+++ b/derive_macros/src/stream/stream_newtype.rs
@@ -15,10 +15,10 @@ pub(crate) fn stream_newtype(
     label: Option<Label>,
     index: Option<Index>,
     transparent: bool,
-) -> proc_macro2::TokenStream {
-    attr::ensure_empty("newtype field", &field.attrs);
+) -> syn::Result<proc_macro2::TokenStream> {
+    attr::ensure_empty("newtype field", &field.attrs)?;
 
-    if transparent {
+    Ok(if transparent {
         quote!(#path(ref field0) => {
             stream.value(field0)?;
         })
@@ -32,5 +32,5 @@ pub(crate) fn stream_newtype(
             stream.value(field0)?;
             stream.tagged_end(#tag, #label, #index)?;
         })
-    }
+    })
 }

--- a/derive_macros/src/stream/stream_record_tuple.rs
+++ b/derive_macros/src/stream/stream_record_tuple.rs
@@ -1,4 +1,4 @@
-use syn::{spanned::Spanned, Field, Ident, Path};
+use syn::{spanned::Spanned, Error, Field, Ident, Path};
 
 use crate::label::{optional_label_or_ident, Label, LabelValue};
 use crate::{
@@ -34,7 +34,7 @@ pub(crate) fn stream_record_tuple<'a>(
     index: Option<Index>,
     unlabeled_fields: bool,
     unindexed_fields: bool,
-) -> proc_macro2::TokenStream {
+) -> syn::Result<proc_macro2::TokenStream> {
     let tag = quote_optional_tag(tag);
     let label = quote_optional_label(label);
     let index = quote_optional_index(index);
@@ -64,7 +64,7 @@ pub(crate) fn stream_record_tuple<'a>(
                 &attr::FlattenAttr,
             ],
             &field.attrs,
-        );
+        )?;
 
         let i = syn::Index::from(i);
 
@@ -80,7 +80,7 @@ pub(crate) fn stream_record_tuple<'a>(
         );
 
         let label = if unlabeled_fields {
-            attr::ensure_missing("struct field", attr::LabelAttr, &field.attrs);
+            attr::ensure_missing("struct field", attr::LabelAttr, &field.attrs)?;
 
             None
         } else {
@@ -91,7 +91,7 @@ pub(crate) fn stream_record_tuple<'a>(
         };
 
         let index = if unindexed_fields {
-            attr::ensure_missing("struct field", attr::IndexAttr, &field.attrs);
+            attr::ensure_missing("struct field", attr::IndexAttr, &field.attrs)?;
 
             None
         } else {
@@ -192,14 +192,18 @@ pub(crate) fn stream_record_tuple<'a>(
         field_count += 1;
     }
 
-    assert!(
-        labeled_field_count == 0 || labeled_field_count == field_count,
-        "if any fields have a label then all fields need one"
-    );
-    assert!(
-        indexed_field_count == 0 || indexed_field_count == field_count,
-        "if any fields have an index then all fields need one"
-    );
+    if labeled_field_count != 0 && labeled_field_count != field_count {
+        return Err(Error::new(
+            proc_macro2::Span::call_site(),
+            "if any fields have a label then all fields need one",
+        ));
+    }
+    if indexed_field_count != 0 && indexed_field_count != field_count {
+        return Err(Error::new(
+            proc_macro2::Span::call_site(),
+            "if any fields have an index then all fields need one",
+        ));
+    }
 
     let field_count = if const_size {
         quote!(sval::__private::option::Option::Some(#field_count))
@@ -207,7 +211,7 @@ pub(crate) fn stream_record_tuple<'a>(
         quote!(sval::__private::option::Option::None)
     };
 
-    match target {
+    Ok(match target {
         RecordTupleTarget::RecordTuple => {
             quote!(#path { #(#field_binding,)* } => {
                 stream.record_tuple_begin(#tag, #label, #index, #field_count)?;
@@ -260,7 +264,7 @@ pub(crate) fn stream_record_tuple<'a>(
                 stream.tagged_end(#tag, #label, #index)?;
             })
         }
-    }
+    })
 }
 
 fn get_field(index: &syn::Index, field: &Field) -> (Ident, proc_macro2::TokenStream) {

--- a/derive_macros/src/stream/stream_record_tuple.rs
+++ b/derive_macros/src/stream/stream_record_tuple.rs
@@ -1,4 +1,4 @@
-use syn::{spanned::Spanned, Error, Field, Ident, Path};
+use syn::{spanned::Spanned, Field, Ident, Path};
 
 use crate::label::{optional_label_or_ident, Label, LabelValue};
 use crate::{
@@ -193,13 +193,13 @@ pub(crate) fn stream_record_tuple<'a>(
     }
 
     if labeled_field_count != 0 && labeled_field_count != field_count {
-        return Err(Error::new(
+        return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
             "if any fields have a label then all fields need one",
         ));
     }
     if indexed_field_count != 0 && indexed_field_count != field_count {
-        return Err(Error::new(
+        return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
             "if any fields have an index then all fields need one",
         ));

--- a/derive_macros/src/stream/stream_record_tuple.rs
+++ b/derive_macros/src/stream/stream_record_tuple.rs
@@ -68,7 +68,7 @@ pub(crate) fn stream_record_tuple<'a>(
 
         let i = syn::Index::from(i);
 
-        if attr::get_unchecked("struct field", attr::SkipAttr, &field.attrs).unwrap_or(false) {
+        if attr::get_unchecked("struct field", attr::SkipAttr, &field.attrs)?.unwrap_or(false) {
             field_binding.push(quote_field_skip(&i, field));
             continue;
         }
@@ -76,7 +76,7 @@ pub(crate) fn stream_record_tuple<'a>(
         let (ident, binding) = get_field(&i, field);
 
         let field_tag = quote_optional_tag(
-            attr::get_unchecked("struct field", attr::TagAttr, &field.attrs).as_ref(),
+            attr::get_unchecked("struct field", attr::TagAttr, &field.attrs)?.as_ref(),
         );
 
         let label = if unlabeled_fields {
@@ -85,7 +85,7 @@ pub(crate) fn stream_record_tuple<'a>(
             None
         } else {
             get_label(
-                attr::get_unchecked("struct field", attr::LabelAttr, &field.attrs),
+                attr::get_unchecked("struct field", attr::LabelAttr, &field.attrs)?,
                 field.ident.as_ref(),
             )
         };
@@ -97,17 +97,17 @@ pub(crate) fn stream_record_tuple<'a>(
         } else {
             Some(quote_index(index_allocator.next_computed_index(
                 &index_ident,
-                attr::get_unchecked("struct field", attr::IndexAttr, &field.attrs),
+                attr::get_unchecked("struct field", attr::IndexAttr, &field.attrs)?,
             )))
         };
 
         let flatten =
-            attr::get_unchecked("struct field", attr::FlattenAttr, &field.attrs).unwrap_or(false);
+            attr::get_unchecked("struct field", attr::FlattenAttr, &field.attrs)?.unwrap_or(false);
 
         const_size = const_size && !flatten;
 
         let value = if let Some(data_tag) =
-            attr::get_unchecked("struct field", attr::DataTagAttr, &field.attrs)
+            attr::get_unchecked("struct field", attr::DataTagAttr, &field.attrs)?
         {
             let data_tag = quote_optional_tag(Some(&data_tag));
             let data_label = quote_optional_label(None);

--- a/derive_macros/src/stream/stream_record_tuple.rs
+++ b/derive_macros/src/stream/stream_record_tuple.rs
@@ -68,16 +68,15 @@ pub(crate) fn stream_record_tuple<'a>(
 
         let i = syn::Index::from(i);
 
-        if attr::get_unchecked("struct field", attr::SkipAttr, &field.attrs)?.unwrap_or(false) {
+        if attr::get("struct field", attr::SkipAttr, &field.attrs)?.unwrap_or(false) {
             field_binding.push(quote_field_skip(&i, field));
             continue;
         }
 
         let (ident, binding) = get_field(&i, field);
 
-        let field_tag = quote_optional_tag(
-            attr::get_unchecked("struct field", attr::TagAttr, &field.attrs)?.as_ref(),
-        );
+        let field_tag =
+            quote_optional_tag(attr::get("struct field", attr::TagAttr, &field.attrs)?.as_ref());
 
         let label = if unlabeled_fields {
             attr::ensure_missing("struct field", attr::LabelAttr, &field.attrs)?;
@@ -85,7 +84,7 @@ pub(crate) fn stream_record_tuple<'a>(
             None
         } else {
             get_label(
-                attr::get_unchecked("struct field", attr::LabelAttr, &field.attrs)?,
+                attr::get("struct field", attr::LabelAttr, &field.attrs)?,
                 field.ident.as_ref(),
             )
         };
@@ -97,30 +96,28 @@ pub(crate) fn stream_record_tuple<'a>(
         } else {
             Some(quote_index(index_allocator.next_computed_index(
                 &index_ident,
-                attr::get_unchecked("struct field", attr::IndexAttr, &field.attrs)?,
+                attr::get("struct field", attr::IndexAttr, &field.attrs)?,
             )))
         };
 
-        let flatten =
-            attr::get_unchecked("struct field", attr::FlattenAttr, &field.attrs)?.unwrap_or(false);
+        let flatten = attr::get("struct field", attr::FlattenAttr, &field.attrs)?.unwrap_or(false);
 
         const_size = const_size && !flatten;
 
-        let value = if let Some(data_tag) =
-            attr::get_unchecked("struct field", attr::DataTagAttr, &field.attrs)?
-        {
-            let data_tag = quote_optional_tag(Some(&data_tag));
-            let data_label = quote_optional_label(None);
-            let data_index = quote_optional_index(None);
+        let value =
+            if let Some(data_tag) = attr::get("struct field", attr::DataTagAttr, &field.attrs)? {
+                let data_tag = quote_optional_tag(Some(&data_tag));
+                let data_label = quote_optional_label(None);
+                let data_index = quote_optional_index(None);
 
-            quote!({
-                stream.tagged_begin(#data_tag, #data_label, #data_index)?;
-                stream.value(#ident)?;
-                stream.tagged_end(#data_tag, #data_label, #data_index)?
-            })
-        } else {
-            quote!(stream.value(#ident)?)
-        };
+                quote!({
+                    stream.tagged_begin(#data_tag, #data_label, #data_index)?;
+                    stream.value(#ident)?;
+                    stream.tagged_end(#data_tag, #data_label, #data_index)?
+                })
+            } else {
+                quote!(stream.value(#ident)?)
+            };
 
         match (&label, &index) {
             (Some(label), Some(index)) => {

--- a/derive_macros/src/stream/stream_tag.rs
+++ b/derive_macros/src/stream/stream_tag.rs
@@ -12,12 +12,12 @@ pub(crate) fn stream_tag(
     tag: Option<&Path>,
     label: Option<Label>,
     index: Option<Index>,
-) -> proc_macro2::TokenStream {
+) -> syn::Result<proc_macro2::TokenStream> {
     let tag = quote_optional_tag(tag);
     let label = quote_optional_label(label);
     let index = quote_optional_index(index);
 
-    quote!(#path => {
+    Ok(quote!(#path => {
         stream.tag(#tag, #label, #index)?;
-    })
+    }))
 }


### PR DESCRIPTION
Closes #197 

This PR is a long overdue refactoring of the `#[derive]` macro internals to use `syn::Error` instead of panicking on invalid input.

-----

**AI Disclosure:** The initial port was done using an agent, specifically Qwen 3.5 27B running locally. I've reviewed and further modified the result.