### PR TITLE
Impl Value for more std::collections types

### DIFF
--- a/src/data/seq.rs
+++ b/src/data/seq.rs
@@ -219,11 +219,91 @@ tuple! {
 mod alloc_support {
     use super::*;
 
-    use crate::std::vec::Vec;
+    use crate::std::{
+        collections::{BTreeSet, BinaryHeap, LinkedList, VecDeque},
+        vec::Vec,
+    };
 
     impl<T: Value> Value for Vec<T> {
         fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
             (&**self).stream(stream)
+        }
+    }
+
+    impl<T: Value> Value for BTreeSet<T> {
+        fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
+            stream.seq_begin(Some(self.len()))?;
+
+            for elem in self {
+                stream.seq_value_begin()?;
+                stream.value(elem)?;
+                stream.seq_value_end()?;
+            }
+
+            stream.seq_end()
+        }
+    }
+
+    impl<T: Value> Value for VecDeque<T> {
+        fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
+            stream.seq_begin(Some(self.len()))?;
+
+            for elem in self {
+                stream.seq_value_begin()?;
+                stream.value(elem)?;
+                stream.seq_value_end()?;
+            }
+
+            stream.seq_end()
+        }
+    }
+
+    impl<T: Value> Value for LinkedList<T> {
+        fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
+            stream.seq_begin(Some(self.len()))?;
+
+            for elem in self {
+                stream.seq_value_begin()?;
+                stream.value(elem)?;
+                stream.seq_value_end()?;
+            }
+
+            stream.seq_end()
+        }
+    }
+
+    impl<T: Value> Value for BinaryHeap<T> {
+        fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
+            stream.seq_begin(Some(self.len()))?;
+
+            for elem in self {
+                stream.seq_value_begin()?;
+                stream.value(elem)?;
+                stream.seq_value_end()?;
+            }
+
+            stream.seq_end()
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_support {
+    use super::*;
+
+    use crate::std::{collections::HashSet, hash::BuildHasher};
+
+    impl<T: Value, H: BuildHasher> Value for HashSet<T, H> {
+        fn stream<'a, S: Stream<'a> + ?Sized>(&'a self, stream: &mut S) -> Result {
+            stream.seq_begin(Some(self.len()))?;
+
+            for elem in self {
+                stream.seq_value_begin()?;
+                stream.value(elem)?;
+                stream.seq_value_end()?;
+            }
+
+            stream.seq_end()
         }
     }
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -856,7 +856,7 @@ mod tests {
     use super::*;
 
     use std::{
-        collections::{BTreeMap, HashMap},
+        collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
         fmt,
     };
 
@@ -1070,6 +1070,137 @@ mod tests {
                 Token::I32(3),
                 Token::TupleValueEnd(None, sval::Index::new(2)),
                 Token::TupleEnd(None, None, None),
+            ],
+        );
+    }
+
+    #[test]
+    fn stream_set_empty() {
+        assert_tokens(
+            &BTreeSet::<u8>::new(),
+            &[Token::SeqBegin(Some(0)), Token::SeqEnd],
+        );
+        assert_tokens(
+            &HashSet::<u8>::new(),
+            &[Token::SeqBegin(Some(0)), Token::SeqEnd],
+        );
+    }
+
+    #[test]
+    fn stream_set() {
+        let set = {
+            let mut set = BTreeSet::new();
+            set.insert(1);
+            set.insert(2);
+            set
+        };
+        assert_tokens(
+            &set,
+            &[
+                Token::SeqBegin(Some(2)),
+                Token::SeqValueBegin,
+                Token::I32(1),
+                Token::SeqValueEnd,
+                Token::SeqValueBegin,
+                Token::I32(2),
+                Token::SeqValueEnd,
+                Token::SeqEnd,
+            ],
+        );
+
+        let set = {
+            let mut set = HashSet::new();
+            set.insert(1);
+            set
+        };
+        assert_tokens(
+            &set,
+            &[
+                Token::SeqBegin(Some(1)),
+                Token::SeqValueBegin,
+                Token::I32(1),
+                Token::SeqValueEnd,
+                Token::SeqEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn stream_seq_collection_empty() {
+        assert_tokens(
+            &VecDeque::<u8>::new(),
+            &[Token::SeqBegin(Some(0)), Token::SeqEnd],
+        );
+        assert_tokens(
+            &LinkedList::<u8>::new(),
+            &[Token::SeqBegin(Some(0)), Token::SeqEnd],
+        );
+        assert_tokens(
+            &BinaryHeap::<u8>::new(),
+            &[Token::SeqBegin(Some(0)), Token::SeqEnd],
+        );
+    }
+
+    #[test]
+    fn stream_seq_collection() {
+        let deque = {
+            let mut deque = VecDeque::new();
+            deque.push_back(1);
+            deque.push_back(2);
+            deque
+        };
+        assert_tokens(
+            &deque,
+            &[
+                Token::SeqBegin(Some(2)),
+                Token::SeqValueBegin,
+                Token::I32(1),
+                Token::SeqValueEnd,
+                Token::SeqValueBegin,
+                Token::I32(2),
+                Token::SeqValueEnd,
+                Token::SeqEnd,
+            ],
+        );
+
+        let list = {
+            let mut list = LinkedList::new();
+            list.push_back(1);
+            list.push_back(2);
+            list
+        };
+        assert_tokens(
+            &list,
+            &[
+                Token::SeqBegin(Some(2)),
+                Token::SeqValueBegin,
+                Token::I32(1),
+                Token::SeqValueEnd,
+                Token::SeqValueBegin,
+                Token::I32(2),
+                Token::SeqValueEnd,
+                Token::SeqEnd,
+            ],
+        );
+
+        let heap = {
+            let mut heap = BinaryHeap::new();
+            heap.push(1);
+            heap.push(2);
+            heap
+        };
+        assert_tokens(
+            &heap,
+            &[
+                Token::SeqBegin(Some(2)),
+                Token::SeqValueBegin,
+                // BinaryHeap iterates in reverse-sorted order (max first)
+                Token::I32(2),
+                Token::SeqValueEnd,
+                Token::SeqValueBegin,
+                Token::I32(1),
+                Token::SeqValueEnd,
+                Token::SeqEnd,
             ],
         );
     }


### PR DESCRIPTION
This PR adds a few missing `Value` impls for `std::collections` types. Each of these behaves like a sequence, so follows the convention of `Vec`.

-----

**AI Disclosure:** This work was assisted by agentic tooling, specifically Qwen 3.6 27B running locally. I've reviewed the result.